### PR TITLE
bumped package to new version, added error handling

### DIFF
--- a/components/useCalibration.js
+++ b/components/useCalibration.js
@@ -175,14 +175,38 @@ export const calibrateAudio = async (reader) => {
         siteUrl: "https://hqjq0u.deta.dev",
         targetElementId: "soundDisplay",
       };
-      const { Speaker, VolumeCalibration } = speakerCalibrator;
+      const calibratorParams = {
+        numCalibrationRounds: 2,
+        numCalibrationNodes: 2,
+        download: false,
+      };
+      const {
+        Speaker,
+        VolumeCalibration,
+        UnsupportedDeviceError,
+        MissingSpeakerIdError,
+        CalibrationTimedOutError,
+      } = speakerCalibrator;
       document.querySelector("#soundMessage").innerHTML = copy.qr;
       document.querySelector("#soundYes").style.display = "none";
       document.querySelector("#soundNo").style.display = "none";
-      soundGainDBSPL.current = await Speaker.startCalibration(
-        speakerParameters,
-        VolumeCalibration
-      );
+      try {
+        soundGainDBSPL.current = await Speaker.startCalibration(
+          speakerParameters,
+          VolumeCalibration,
+          calibratorParams
+        );
+      } catch (e) {
+        if (e instanceof UnsupportedDeviceError) {
+          // Do something here
+        }
+        if (e instanceof MissingSpeakerIdError) {
+          // Do something here
+        }
+        if (e instanceof CalibrationTimedOutError) {
+          // Do something here
+        }
+      }
 
       elems.display.style.display = "none";
       elems.message.innerHTML =

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
 
     <!-- external libraries -->
     <script src="https://cdn.jsdelivr.net/npm/remote-calibrator@0.6.1"></script>
-    <script src="https://unpkg.com/speaker-calibration@1.0.9/dist/main.js"></script>
+    <script src="https://unpkg.com/speaker-calibration@1.1.2/dist/main.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/marked@4.0.7/marked.min.js"></script>
     <!-- PsychoJS originals -->
     <script src="https://cdn.jsdelivr.net/npm/jquery@3.6.0/dist/jquery.min.js"></script>


### PR DESCRIPTION
@aburchell I bumped the package version and added error handling guards. What to do with the caught errors is up to the team. The use-case for the `ImpulseResponseCalibration` task will follow the exact same API.   