### PR TITLE
Align crowding bounds with the displayed triplet

### DIFF
--- a/components/boundingNew.js
+++ b/components/boundingNew.js
@@ -324,6 +324,7 @@ export const restrictLevelBeforeFixation = (
   fontCharacterSet,
   spacingDirection = "horizontal",
   targetSizeIsHeightBool = false,
+  letterCharacters,
 ) => {
   const quickCase = getQuickCase(
     targetTask,
@@ -347,10 +348,9 @@ export const restrictLevelBeforeFixation = (
     targetString = sampleWithoutReplacement(fontCharacterSet, 1)[0];
     characterSet = targetString;
   } else if (quickCase === "typographicCrowding") {
-    [targetString, flanker1String, flanker2String] = sampleWithoutReplacement(
-      fontCharacterSet,
-      3,
-    );
+    targetString = letterCharacters.target;
+    flanker1String = letterCharacters.flanker1;
+    flanker2String = letterCharacters.flanker2;
     characterSet = [flanker1String, targetString, flanker2String];
   } else if (quickCase === "ratioCrowding") {
     switch (spacingDirection) {

--- a/components/boundingNew.js
+++ b/components/boundingNew.js
@@ -348,9 +348,20 @@ export const restrictLevelBeforeFixation = (
     targetString = sampleWithoutReplacement(fontCharacterSet, 1)[0];
     characterSet = targetString;
   } else if (quickCase === "typographicCrowding") {
-    targetString = letterCharacters.target;
-    flanker1String = letterCharacters.flanker1;
-    flanker2String = letterCharacters.flanker2;
+    const { target, flanker1, flanker2 } = letterCharacters ?? {};
+    const selectedCharacters = [target, flanker1, flanker2];
+    if (
+      selectedCharacters.some(
+        (character) => typeof character !== "string" || character.length === 0,
+      )
+    ) {
+      throw new Error(
+        "Typographic crowding requires a selected target and two flankers.",
+      );
+    }
+    targetString = target;
+    flanker1String = flanker1;
+    flanker2String = flanker2;
     characterSet = [flanker1String, targetString, flanker2String];
   } else if (quickCase === "ratioCrowding") {
     switch (spacingDirection) {

--- a/components/stimulusGeneration.ts
+++ b/components/stimulusGeneration.ts
@@ -28,6 +28,7 @@ import type {
   RsvpReadingStimulusResults,
   VernierStimulusResults,
   TextStimsLetter,
+  CharactersLetter,
 } from "./stimulus";
 import { rc, viewingDistanceCm } from "./global";
 import { Screens } from "./multiple-displays/globals";
@@ -127,7 +128,7 @@ const getLettersStimulus = (
         reader,
         extraInfo.characterSetBoundingRect,
         extraInfo.stage as PartOfTrial,
-        extraInfo.characters.target,
+        extraInfo.characters,
         extraInfo.proposedLevel,
       ));
   }
@@ -272,13 +273,14 @@ const getLettersStimulusV2 = (
   reader: ParamReader,
   characterSetBoundingRectOld: any,
   stage: PartOfTrial,
-  targetCharacter?: string,
+  letterCharacters: CharactersLetter,
   proposedLevel?: number,
 ): {
   level: number;
   stimulusParameters: any;
   characterSetBoundingRect: any;
 } => {
+  const targetCharacter = letterCharacters.target;
   if (stage === "afterFixation" && !(targetCharacter && proposedLevel)) {
     throw new Error(
       `targetCharacter (${targetCharacter}) and proposedLevel (${proposedLevel}) must be provided for afterFixation letter stimulus generation.`,
@@ -304,6 +306,7 @@ const getLettersStimulusV2 = (
       String(reader.read("fontCharacterSet", block_condition)).split(""),
       reader.read("spacingDirection", block_condition),
       reader.read("targetSizeIsHeightBool", block_condition),
+      letterCharacters,
     );
   } else if (stage === "afterFixation") {
     [level, stimulusParameters] = restrictLevelAfterFixation(


### PR DESCRIPTION
## What I noticed

While running Persian experiment with IranNastaliq, I saw the triplet occasionally render partly off the
bottom of the screen. In this trial the fixation cross is centred, but the
triplet has dropped below and is clipped by the screen edge:



I wanted to understand where that size was coming from, so I cloned the repo and
traced the letter-stimulus path. I might be missing context, so I'm sharing this
as something I noticed rather than a firm diagnosis.

## What seems to be happening

For a typographic-crowding trial, two places pick characters, and I think they
can quietly disagree:

1. The stimulus-generation path selects the target and flankers the participant
   actually sees, and renders them as one joined string
   (`flanker1 + target + flanker2`).
2. Separately, `restrictLevelBeforeFixation` samples another three characters
   from `fontCharacterSet` and measures *that* triplet to decide how large the
   stimulus may be.

Because these are two independent draws, the triplet measured for the bounds can
be a different string from the one drawn on screen. For most fonts their widths
are close, so it never shows. IranNastaliq is contextual, though (letters join
and reshape depending on their neighbours) so two different triplets can have
quite different joined widths. When the measured proxy is much narrower than the
displayed triplet, the size cap comes out too generous and the real triplet can
extend past the screen edge, which is what the screenshot above shows.

To see it more concretely I built a small standalone reproduction (the hidden
measured triplet on the left, the displayed triplet with its calculated vs
actual bounds below):
<img width="1917" height="1078" alt="observed-iran-nastaliq-overflow" src="https://github.com/user-attachments/assets/88bf25f9-cc0f-436e-b668-c55b03ee03d5" />



## Why it can matter

In Persian the letters join together, so two different triplets can have very
different shapes and widths. The code uses that width to choose the stimulus
size and to keep it on the screen. So when the size is measured on one triplet
but a different triplet is shown, the participant can see a different size and
spacing than intended, and if the width difference is large (which it easily is
in Persian), the triplet can even run off the screen, as above.

It also affects QUEST. Each trial QUEST picks a spacing and records the response
at the spacing it asked for, but the spacing actually shown depends on the
displayed triplet's width, and not the measured one. So when those widths differ a lot, the presented spacing is off by a lot, and because a new proxy is drawn for every trial, that error changes from trial to trial, so QUEST ends up adapting to spacings that weren't really the ones presented. (in my opinion)

<img width="1440" height="2683" alt="triplet-bounding-reproduction" src="https://github.com/user-attachments/assets/33313188-701f-47a3-9f11-855f3d47870e" />



## What this PR proposes

A small change: pass the target and flankers already chosen for the trial into
the bounding step, so it measures exactly the string that will be displayed
(`flanker1 + target + flanker2`). Acuity and ratio-crowding keep sampling
exactly as before.
