### PR TITLE
Add RSVP speech microphone preflight foundation

### DIFF
--- a/components/css/rsvpSpeechPreflight.css
+++ b/components/css/rsvpSpeechPreflight.css
@@ -1,0 +1,30 @@
+.rsvp-speech-preflight {
+  position: fixed;
+  z-index: 999998;
+  left: 50%;
+  bottom: 5rem;
+  width: min(42rem, calc(100vw - 4rem));
+  transform: translateX(-50%);
+  text-align: center;
+  font-family: inherit;
+}
+
+.rsvp-speech-preflight__message {
+  margin: 0;
+  padding: 0.8rem 1rem;
+  border-radius: 0.5rem;
+  background: rgb(255 255 255 / 92%);
+  color: #111;
+  font-size: 1.1rem;
+  line-height: 1.4;
+}
+
+.rsvp-speech-preflight__button:disabled {
+  cursor: wait;
+  opacity: 0.7;
+}
+
+.rsvp-speech-preflight__button {
+  left: 50%;
+  transform: translateX(-50%);
+}

--- a/components/global.js
+++ b/components/global.js
@@ -788,6 +788,15 @@ export const rsvpReadingResponse = {
   responseTypeForCurrentBlock: [],
 };
 
+/** @type {{completed: boolean, required: boolean, status: string, block: number | undefined, lastFailureCode: string | undefined}} */
+export const rsvpSpeechPreflight = {
+  completed: false,
+  required: false,
+  status: "idle",
+  block: undefined,
+  lastFailureCode: undefined,
+};
+
 export const rsvpReadingTiming = {
   current: {
     startSec: undefined,

--- a/components/lifetime.js
+++ b/components/lifetime.js
@@ -31,6 +31,7 @@ import { useMatlab, closeMatlab } from "./connectMatlab";
 import { readi18nPhrases } from "./readPhrases.js";
 import { renderMarkdown } from "./markdownInline.js";
 import { PsychoJS } from "../psychojs/src/core/index.js";
+import { cancelActiveRsvpSpeechPreflight } from "./speech/speechPreflight.ts";
 
 export async function quitPsychoJS(
   message = "",
@@ -47,6 +48,7 @@ export async function quitPsychoJS(
     return;
 
   // Clean up any lingering error dialogs before showing debrief/close screens
+  cancelActiveRsvpSpeechPreflight();
   try {
     document
       .querySelectorAll(".ui-dialog, #msgDialog, #expDialog")

--- a/components/speech/audioSignal.ts
+++ b/components/speech/audioSignal.ts
@@ -1,0 +1,95 @@
+export interface AudioSignalMetrics {
+  sampleCount: number;
+  rms: number;
+  rmsDbfs: number;
+  acRms: number;
+  acRmsDbfs: number;
+  peak: number;
+  dcOffset: number;
+  zeroSampleRatio: number;
+  clippedSampleRatio: number;
+}
+
+export interface AudioSignalMetricOptions {
+  zeroEpsilon?: number;
+  clippingThreshold?: number;
+}
+
+const validateMetricOptions = ({
+  zeroEpsilon,
+  clippingThreshold,
+}: Required<AudioSignalMetricOptions>): void => {
+  if (!Number.isFinite(zeroEpsilon) || zeroEpsilon < 0) {
+    throw new RangeError("zeroEpsilon must be a finite non-negative number.");
+  }
+  if (
+    !Number.isFinite(clippingThreshold) ||
+    clippingThreshold <= 0 ||
+    clippingThreshold > 1
+  ) {
+    throw new RangeError(
+      "clippingThreshold must be a finite number greater than 0 and at most 1.",
+    );
+  }
+};
+
+export const calculateAudioSignalMetrics = (
+  samples: Float32Array,
+  options: AudioSignalMetricOptions = {},
+): AudioSignalMetrics => {
+  const resolvedOptions = {
+    zeroEpsilon: options.zeroEpsilon ?? 1e-7,
+    clippingThreshold: options.clippingThreshold ?? 0.99,
+  };
+  validateMetricOptions(resolvedOptions);
+
+  if (samples.length === 0) {
+    return {
+      sampleCount: 0,
+      rms: 0,
+      rmsDbfs: Number.NEGATIVE_INFINITY,
+      acRms: 0,
+      acRmsDbfs: Number.NEGATIVE_INFINITY,
+      peak: 0,
+      dcOffset: 0,
+      zeroSampleRatio: 1,
+      clippedSampleRatio: 0,
+    };
+  }
+
+  let sum = 0;
+  let squaredSum = 0;
+  let peak = 0;
+  let zeroSamples = 0;
+  let clippedSamples = 0;
+
+  for (const sample of samples) {
+    if (!Number.isFinite(sample)) {
+      throw new RangeError("Audio samples must contain only finite values.");
+    }
+
+    const magnitude = Math.abs(sample);
+    sum += sample;
+    squaredSum += sample * sample;
+    peak = Math.max(peak, magnitude);
+    if (magnitude <= resolvedOptions.zeroEpsilon) zeroSamples += 1;
+    if (magnitude >= resolvedOptions.clippingThreshold) clippedSamples += 1;
+  }
+
+  const meanSquare = squaredSum / samples.length;
+  const dcOffset = sum / samples.length;
+  const rms = Math.sqrt(meanSquare);
+  const acRms = Math.sqrt(Math.max(0, meanSquare - dcOffset * dcOffset));
+
+  return {
+    sampleCount: samples.length,
+    rms,
+    rmsDbfs: rms === 0 ? Number.NEGATIVE_INFINITY : 20 * Math.log10(rms),
+    acRms,
+    acRmsDbfs: acRms === 0 ? Number.NEGATIVE_INFINITY : 20 * Math.log10(acRms),
+    peak,
+    dcOffset,
+    zeroSampleRatio: zeroSamples / samples.length,
+    clippedSampleRatio: clippedSamples / samples.length,
+  };
+};

--- a/components/speech/microphone.ts
+++ b/components/speech/microphone.ts
@@ -1,0 +1,506 @@
+export type MicrophoneErrorCode =
+  | "unsupported"
+  | "permissionDenied"
+  | "permissionTimeout"
+  | "deviceNotFound"
+  | "deviceUnavailable"
+  | "constraintsUnsupported"
+  | "noAudioTrack"
+  | "audioGraphUnavailable"
+  | "inputEnded"
+  | "sessionClosed"
+  | "invalidConfiguration"
+  | "unexpected";
+
+export class MicrophoneError extends Error {
+  readonly code: MicrophoneErrorCode;
+  readonly originalError?: unknown;
+
+  constructor(
+    code: MicrophoneErrorCode,
+    message: string,
+    originalError?: unknown,
+  ) {
+    super(message);
+    this.name = "MicrophoneError";
+    this.code = code;
+    this.originalError = originalError;
+  }
+}
+
+export type MicrophoneHealthState =
+  | "ready"
+  | "muted"
+  | "disabled"
+  | "ended"
+  | "closed";
+
+export interface MicrophoneHealth {
+  state: MicrophoneHealthState;
+  readyState: MediaStreamTrackState;
+  enabled: boolean;
+  muted: boolean;
+}
+
+export type MicrophoneHealthListener = (health: MicrophoneHealth) => void;
+
+export interface MicrophoneSession {
+  readonly stream: MediaStream;
+  readonly track: MediaStreamTrack;
+  readonly frameSize: number;
+  readonly sampleRate: number;
+  readonly frameDurationMs: number;
+  getHealth(): MicrophoneHealth;
+  getTrackSettings(): MediaTrackSettings;
+  readFrame(target: Float32Array): void;
+  subscribeToHealth(listener: MicrophoneHealthListener): () => void;
+  close(): Promise<void>;
+}
+
+export interface OpenMicrophoneOptions {
+  audioConstraints?: boolean | MediaTrackConstraints;
+  analyserFftSize?: number;
+  permissionTimeoutMs?: number;
+  mediaDevices?: Pick<MediaDevices, "getUserMedia">;
+  createAudioContext?: () => AudioContext;
+}
+
+const DEFAULT_ANALYSER_FFT_SIZE = 2048;
+const MIN_ANALYSER_FFT_SIZE = 32;
+const MAX_ANALYSER_FFT_SIZE = 32768;
+
+const createFloatTimeDomainBuffer = (length: number) =>
+  new Float32Array(length);
+const createByteTimeDomainBuffer = (length: number) => new Uint8Array(length);
+
+const isPowerOfTwo = (value: number): boolean =>
+  value > 0 && (value & (value - 1)) === 0;
+
+const validateAnalyserFftSize = (fftSize: number): void => {
+  if (
+    !Number.isInteger(fftSize) ||
+    !isPowerOfTwo(fftSize) ||
+    fftSize < MIN_ANALYSER_FFT_SIZE ||
+    fftSize > MAX_ANALYSER_FFT_SIZE
+  ) {
+    throw new MicrophoneError(
+      "invalidConfiguration",
+      `analyserFftSize must be a power of two from ${MIN_ANALYSER_FFT_SIZE} through ${MAX_ANALYSER_FFT_SIZE}.`,
+    );
+  }
+};
+
+const validatePermissionTimeout = (timeoutMs?: number): void => {
+  if (
+    timeoutMs !== undefined &&
+    (!Number.isFinite(timeoutMs) || timeoutMs <= 0)
+  ) {
+    throw new MicrophoneError(
+      "invalidConfiguration",
+      "permissionTimeoutMs must be a finite positive number.",
+    );
+  }
+};
+
+const getDefaultMediaDevices = ():
+  | Pick<MediaDevices, "getUserMedia">
+  | undefined =>
+  typeof navigator === "undefined" ? undefined : navigator.mediaDevices;
+
+const createDefaultAudioContext = (): AudioContext => {
+  const webkitGlobal = globalThis as typeof globalThis & {
+    webkitAudioContext?: typeof AudioContext;
+  };
+  const AudioContextConstructor =
+    typeof AudioContext === "undefined"
+      ? webkitGlobal.webkitAudioContext
+      : AudioContext;
+
+  if (!AudioContextConstructor) {
+    throw new MicrophoneError(
+      "audioGraphUnavailable",
+      "The Web Audio API is unavailable in this browser.",
+    );
+  }
+  return new AudioContextConstructor();
+};
+
+const errorName = (error: unknown): string | undefined => {
+  if (typeof error !== "object" || error === null || !("name" in error)) {
+    return undefined;
+  }
+  return typeof error.name === "string" ? error.name : undefined;
+};
+
+const mapGetUserMediaError = (error: unknown): MicrophoneError => {
+  if (error instanceof MicrophoneError) return error;
+
+  switch (errorName(error)) {
+    case "NotAllowedError":
+    case "PermissionDeniedError":
+    case "SecurityError":
+      return new MicrophoneError(
+        "permissionDenied",
+        "Microphone permission was denied.",
+        error,
+      );
+    case "NotFoundError":
+    case "DevicesNotFoundError":
+      return new MicrophoneError(
+        "deviceNotFound",
+        "No microphone input device was found.",
+        error,
+      );
+    case "NotReadableError":
+    case "TrackStartError":
+    case "AbortError":
+      return new MicrophoneError(
+        "deviceUnavailable",
+        "The microphone is unavailable or could not be started.",
+        error,
+      );
+    case "OverconstrainedError":
+    case "ConstraintNotSatisfiedError":
+      return new MicrophoneError(
+        "constraintsUnsupported",
+        "The requested microphone constraints are not supported.",
+        error,
+      );
+    default:
+      return new MicrophoneError(
+        "unexpected",
+        "An unexpected error occurred while opening the microphone.",
+        error,
+      );
+  }
+};
+
+const stopAllTracks = (stream: MediaStream): void => {
+  for (const track of stream.getTracks()) {
+    try {
+      track.stop();
+    } catch {
+      // One failed track must not prevent the remaining tracks from stopping.
+    }
+  }
+};
+
+const disconnectAudioNode = (node?: AudioNode): void => {
+  try {
+    node?.disconnect();
+  } catch {
+    // A disconnected node is already in the desired cleanup state.
+  }
+};
+
+const closeAudioContext = async (
+  audioContext?: AudioContext,
+): Promise<void> => {
+  if (!audioContext || audioContext.state === "closed") return;
+  try {
+    await audioContext.close();
+  } catch {
+    // Media tracks are already stopped; a close rejection must not leak cleanup.
+  }
+};
+
+class BrowserMicrophoneSession implements MicrophoneSession {
+  readonly stream: MediaStream;
+  readonly track: MediaStreamTrack;
+  readonly frameSize: number;
+  readonly sampleRate: number;
+  readonly frameDurationMs: number;
+
+  private readonly audioContext: AudioContext;
+  private readonly sourceNode: MediaStreamAudioSourceNode;
+  private readonly analyserNode: AnalyserNode;
+  private readonly floatFrame: ReturnType<typeof createFloatTimeDomainBuffer>;
+  private readonly byteFrame: ReturnType<typeof createByteTimeDomainBuffer>;
+  private readonly healthListeners = new Set<MicrophoneHealthListener>();
+  private closePromise?: Promise<void>;
+  private closed = false;
+
+  constructor(
+    stream: MediaStream,
+    track: MediaStreamTrack,
+    audioContext: AudioContext,
+    sourceNode: MediaStreamAudioSourceNode,
+    analyserNode: AnalyserNode,
+  ) {
+    this.stream = stream;
+    this.track = track;
+    this.audioContext = audioContext;
+    this.sourceNode = sourceNode;
+    this.analyserNode = analyserNode;
+    this.frameSize = analyserNode.fftSize;
+    this.sampleRate = audioContext.sampleRate;
+    this.frameDurationMs = (this.frameSize / this.sampleRate) * 1000;
+    this.floatFrame = createFloatTimeDomainBuffer(this.frameSize);
+    this.byteFrame = createByteTimeDomainBuffer(this.frameSize);
+
+    this.track.addEventListener("mute", this.handleTrackHealthChange);
+    this.track.addEventListener("unmute", this.handleTrackHealthChange);
+    this.track.addEventListener("ended", this.handleTrackHealthChange);
+  }
+
+  getHealth(): MicrophoneHealth {
+    let state: MicrophoneHealthState;
+    if (this.closed) state = "closed";
+    else if (this.track.readyState === "ended") state = "ended";
+    else if (!this.track.enabled) state = "disabled";
+    else if (this.track.muted) state = "muted";
+    else state = "ready";
+
+    return {
+      state,
+      readyState: this.track.readyState,
+      enabled: this.track.enabled,
+      muted: this.track.muted,
+    };
+  }
+
+  getTrackSettings(): MediaTrackSettings {
+    return { ...this.track.getSettings() };
+  }
+
+  readFrame(target: Float32Array): void {
+    if (this.closed) {
+      throw new MicrophoneError(
+        "sessionClosed",
+        "Cannot read audio from a closed microphone session.",
+      );
+    }
+    if (this.track.readyState === "ended") {
+      throw new MicrophoneError(
+        "inputEnded",
+        "Cannot read audio because the microphone input has ended.",
+      );
+    }
+    if (target.length !== this.frameSize) {
+      throw new MicrophoneError(
+        "invalidConfiguration",
+        `Audio frame target must contain exactly ${this.frameSize} samples.`,
+      );
+    }
+
+    if (typeof this.analyserNode.getFloatTimeDomainData === "function") {
+      this.analyserNode.getFloatTimeDomainData(this.floatFrame);
+      target.set(this.floatFrame);
+      return;
+    }
+
+    this.analyserNode.getByteTimeDomainData(this.byteFrame);
+    for (let index = 0; index < this.frameSize; index += 1) {
+      target[index] = (this.byteFrame[index] - 128) / 128;
+    }
+  }
+
+  subscribeToHealth(listener: MicrophoneHealthListener): () => void {
+    if (this.closed) {
+      listener(this.getHealth());
+      return () => undefined;
+    }
+
+    this.healthListeners.add(listener);
+    try {
+      listener(this.getHealth());
+    } catch (error) {
+      this.healthListeners.delete(listener);
+      throw error;
+    }
+    return () => this.healthListeners.delete(listener);
+  }
+
+  close(): Promise<void> {
+    this.closePromise ??= this.performClose();
+    return this.closePromise;
+  }
+
+  private readonly handleTrackHealthChange = (): void => {
+    this.notifyHealthListeners();
+  };
+
+  private notifyHealthListeners(): void {
+    const health = this.getHealth();
+    for (const listener of this.healthListeners) {
+      try {
+        listener(health);
+      } catch {
+        // One observer must not interrupt resource cleanup or other observers.
+      }
+    }
+  }
+
+  private async performClose(): Promise<void> {
+    this.closed = true;
+    this.track.removeEventListener("mute", this.handleTrackHealthChange);
+    this.track.removeEventListener("unmute", this.handleTrackHealthChange);
+    this.track.removeEventListener("ended", this.handleTrackHealthChange);
+
+    stopAllTracks(this.stream);
+
+    disconnectAudioNode(this.sourceNode);
+    disconnectAudioNode(this.analyserNode);
+    await closeAudioContext(this.audioContext);
+
+    this.notifyHealthListeners();
+    this.healthListeners.clear();
+  }
+}
+
+export const openMicrophone = async (
+  options: OpenMicrophoneOptions = {},
+): Promise<MicrophoneSession> => {
+  const fftSize = options.analyserFftSize ?? DEFAULT_ANALYSER_FFT_SIZE;
+  validateAnalyserFftSize(fftSize);
+  validatePermissionTimeout(options.permissionTimeoutMs);
+
+  const mediaDevices = options.mediaDevices ?? getDefaultMediaDevices();
+  if (!mediaDevices || typeof mediaDevices.getUserMedia !== "function") {
+    throw new MicrophoneError(
+      "unsupported",
+      "Microphone capture is unavailable in this browser context.",
+    );
+  }
+
+  let audioContext: AudioContext;
+  try {
+    audioContext = (options.createAudioContext ?? createDefaultAudioContext)();
+  } catch (error) {
+    if (error instanceof MicrophoneError) throw error;
+    throw new MicrophoneError(
+      "audioGraphUnavailable",
+      "The microphone audio graph could not be initialized.",
+      error,
+    );
+  }
+
+  let resumePromise: Promise<void>;
+  try {
+    resumePromise =
+      audioContext.state === "suspended"
+        ? audioContext.resume()
+        : Promise.resolve();
+  } catch (error) {
+    await closeAudioContext(audioContext);
+    throw new MicrophoneError(
+      "audioGraphUnavailable",
+      "The microphone audio graph could not be started.",
+      error,
+    );
+  }
+
+  let mediaRequest: Promise<MediaStream>;
+  try {
+    mediaRequest = mediaDevices.getUserMedia({
+      audio: options.audioConstraints ?? true,
+      video: false,
+    });
+  } catch (error) {
+    await closeAudioContext(audioContext);
+    throw mapGetUserMediaError(error);
+  }
+
+  let streamPromise = mediaRequest;
+  if (options.permissionTimeoutMs !== undefined) {
+    streamPromise = new Promise<MediaStream>((resolve, reject) => {
+      let settled = false;
+      const timeoutId = globalThis.setTimeout(() => {
+        settled = true;
+        reject(
+          new MicrophoneError(
+            "permissionTimeout",
+            "Microphone permission was not resolved before the timeout.",
+          ),
+        );
+      }, options.permissionTimeoutMs);
+
+      void mediaRequest.then(
+        (stream) => {
+          if (settled) {
+            stopAllTracks(stream);
+            return;
+          }
+          settled = true;
+          globalThis.clearTimeout(timeoutId);
+          resolve(stream);
+        },
+        (error) => {
+          if (settled) return;
+          settled = true;
+          globalThis.clearTimeout(timeoutId);
+          reject(error);
+        },
+      );
+    });
+  }
+
+  // Start both before the first await so transient user activation is preserved.
+  const [resumeResult, streamResult] = await Promise.allSettled([
+    resumePromise,
+    streamPromise,
+  ]);
+
+  if (streamResult.status === "rejected") {
+    await closeAudioContext(audioContext);
+    throw mapGetUserMediaError(streamResult.reason);
+  }
+
+  const stream = streamResult.value;
+  if (resumeResult.status === "rejected") {
+    stopAllTracks(stream);
+    await closeAudioContext(audioContext);
+    throw new MicrophoneError(
+      "audioGraphUnavailable",
+      "The microphone audio graph could not be started.",
+      resumeResult.reason,
+    );
+  }
+
+  const track = stream.getAudioTracks()[0];
+  if (!track) {
+    stopAllTracks(stream);
+    await closeAudioContext(audioContext);
+    throw new MicrophoneError(
+      "noAudioTrack",
+      "The captured media stream contains no audio track.",
+    );
+  }
+  if (track.readyState === "ended") {
+    stopAllTracks(stream);
+    await closeAudioContext(audioContext);
+    throw new MicrophoneError(
+      "inputEnded",
+      "The microphone input ended before capture could begin.",
+    );
+  }
+
+  let sourceNode: MediaStreamAudioSourceNode | undefined;
+  let analyserNode: AnalyserNode | undefined;
+
+  try {
+    sourceNode = audioContext.createMediaStreamSource(stream);
+    analyserNode = audioContext.createAnalyser();
+    analyserNode.fftSize = fftSize;
+    sourceNode.connect(analyserNode);
+  } catch (error) {
+    stopAllTracks(stream);
+    disconnectAudioNode(sourceNode);
+    disconnectAudioNode(analyserNode);
+    await closeAudioContext(audioContext);
+    if (error instanceof MicrophoneError) throw error;
+    throw new MicrophoneError(
+      "audioGraphUnavailable",
+      "The microphone audio graph could not be initialized.",
+      error,
+    );
+  }
+
+  return new BrowserMicrophoneSession(
+    stream,
+    track,
+    audioContext,
+    sourceNode,
+    analyserNode,
+  );
+};

--- a/components/speech/speechPreflight.ts
+++ b/components/speech/speechPreflight.ts
@@ -160,7 +160,7 @@ const waitForMicrophone = async (
   } catch (error) {
     if (error instanceof SpeechPreflightCancelledError) {
       void request.then(
-        (session) => session.close(),
+        (session) => session.close().catch(() => undefined),
         () => undefined,
       );
     }

--- a/components/speech/speechPreflight.ts
+++ b/components/speech/speechPreflight.ts
@@ -1,0 +1,492 @@
+import { rsvpSpeechPreflight } from "../global";
+import { readi18nPhrases } from "../readPhrases";
+import { calculateAudioSignalMetrics } from "./audioSignal";
+import {
+  MicrophoneError,
+  openMicrophone,
+  type MicrophoneSession,
+  type OpenMicrophoneOptions,
+} from "./microphone";
+import { EnergyVoiceActivityDetector } from "./vad";
+
+export type SpeechPreflightPhase =
+  | "requestingPermission"
+  | "measuringAmbient"
+  | "waitingForVoice";
+
+export type SpeechPreflightFailureCode =
+  | "permissionDenied"
+  | "permissionTimeout"
+  | "microphoneNotFound"
+  | "microphoneUnavailable"
+  | "ambiguousInput"
+  | "voiceNotDetected"
+  | "clippedInput"
+  | "unexpected";
+
+export type SpeechPreflightResult =
+  | {
+      ok: true;
+      sampleRate: number;
+      frameDurationMs: number;
+      noiseFloorAcRms: number;
+      detectedVoiceAcRms: number;
+    }
+  | { ok: false; code: SpeechPreflightFailureCode };
+
+export interface SpeechPreflightCopy {
+  introduction: string;
+  startButton: string;
+  requestingPermission: string;
+  measuringAmbient: string;
+  waitingForVoice: string;
+  success: string;
+  retryButton: string;
+  failures: Record<SpeechPreflightFailureCode, string>;
+}
+
+interface SpeechPreflightRuntimeOptions {
+  ambientDurationMs: number;
+  voiceTimeoutMs: number;
+  permissionTimeoutMs: number;
+  pollIntervalMs: number;
+  minimumVoiceDurationMs: number;
+  speechThresholdDbAboveNoise: number;
+  absoluteSpeechFloorAcRms: number;
+  maximumClippedSampleRatio: number;
+}
+
+export interface RunSpeechPreflightOptions {
+  signal?: AbortSignal;
+  onPhaseChange?: (phase: SpeechPreflightPhase) => void;
+  runtime?: Partial<SpeechPreflightRuntimeOptions>;
+  openMicrophone?: (
+    options?: OpenMicrophoneOptions,
+  ) => Promise<MicrophoneSession>;
+  now?: () => number;
+  wait?: (durationMs: number, signal?: AbortSignal) => Promise<void>;
+}
+
+export interface MountRsvpSpeechPreflightOptions {
+  block: number;
+  language: string;
+  onPassed: () => void;
+  copy?: SpeechPreflightCopy;
+  runPreflight?: (
+    options: RunSpeechPreflightOptions,
+  ) => Promise<SpeechPreflightResult>;
+}
+
+const DEFAULT_RUNTIME_OPTIONS: SpeechPreflightRuntimeOptions = {
+  ambientDurationMs: 750,
+  voiceTimeoutMs: 5000,
+  permissionTimeoutMs: 20000,
+  pollIntervalMs: 50,
+  minimumVoiceDurationMs: 100,
+  speechThresholdDbAboveNoise: 9,
+  absoluteSpeechFloorAcRms: 0.0025,
+  maximumClippedSampleRatio: 0.2,
+};
+
+export const DEFAULT_SPEECH_AUDIO_CONSTRAINTS: MediaTrackConstraints = {
+  channelCount: { ideal: 1 },
+  echoCancellation: { ideal: true },
+  noiseSuppression: { ideal: true },
+  autoGainControl: { ideal: true },
+};
+
+const PREFLIGHT_ELEMENT_ID = "rsvp-speech-preflight";
+
+class SpeechPreflightCancelledError extends Error {
+  constructor() {
+    super("Speech preflight was cancelled.");
+    this.name = "SpeechPreflightCancelledError";
+  }
+}
+
+const throwIfAborted = (signal?: AbortSignal): void => {
+  if (signal?.aborted) throw new SpeechPreflightCancelledError();
+};
+
+const defaultWait = (durationMs: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    throwIfAborted(signal);
+
+    const handleAbort = (): void => {
+      globalThis.clearTimeout(timeoutId);
+      reject(new SpeechPreflightCancelledError());
+    };
+    const timeoutId = globalThis.setTimeout(() => {
+      signal?.removeEventListener("abort", handleAbort);
+      resolve();
+    }, durationMs);
+    signal?.addEventListener("abort", handleAbort, { once: true });
+  });
+
+const percentile = (values: number[], fraction: number): number => {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.min(
+    sorted.length - 1,
+    Math.max(0, Math.ceil(fraction * sorted.length) - 1),
+  );
+  return sorted[index];
+};
+
+const assertUsableTrack = (session: MicrophoneSession): void => {
+  if (session.getHealth().state !== "ready") {
+    throw new MicrophoneError(
+      "deviceUnavailable",
+      "The microphone stopped providing usable input during preflight.",
+    );
+  }
+};
+
+const waitForMicrophone = async (
+  request: Promise<MicrophoneSession>,
+  signal?: AbortSignal,
+): Promise<MicrophoneSession> => {
+  if (!signal) return request;
+  throwIfAborted(signal);
+
+  let handleAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    handleAbort = () => reject(new SpeechPreflightCancelledError());
+    signal.addEventListener("abort", handleAbort, { once: true });
+  });
+
+  try {
+    return await Promise.race([request, aborted]);
+  } catch (error) {
+    if (error instanceof SpeechPreflightCancelledError) {
+      void request.then(
+        (session) => session.close(),
+        () => undefined,
+      );
+    }
+    throw error;
+  } finally {
+    if (handleAbort) signal.removeEventListener("abort", handleAbort);
+  }
+};
+
+const mapFailure = (error: unknown): SpeechPreflightFailureCode => {
+  if (!(error instanceof MicrophoneError)) return "unexpected";
+
+  switch (error.code) {
+    case "permissionDenied":
+      return "permissionDenied";
+    case "permissionTimeout":
+      return "permissionTimeout";
+    case "deviceNotFound":
+    case "noAudioTrack":
+      return "microphoneNotFound";
+    case "unsupported":
+    case "deviceUnavailable":
+    case "constraintsUnsupported":
+    case "audioGraphUnavailable":
+    case "inputEnded":
+    case "sessionClosed":
+      return "microphoneUnavailable";
+    default:
+      return "unexpected";
+  }
+};
+
+export const readRsvpSpeechPreflightCopy = (
+  language: string,
+): SpeechPreflightCopy => ({
+  introduction: readi18nPhrases("T_rsvpSpeechPreflightIntroduction", language),
+  startButton: readi18nPhrases("T_rsvpSpeechPreflightStart", language),
+  requestingPermission: readi18nPhrases(
+    "T_rsvpSpeechPreflightRequestingPermission",
+    language,
+  ),
+  measuringAmbient: readi18nPhrases(
+    "T_rsvpSpeechPreflightMeasuringAmbient",
+    language,
+  ),
+  waitingForVoice: readi18nPhrases(
+    "T_rsvpSpeechPreflightWaitingForVoice",
+    language,
+  ),
+  success: readi18nPhrases("T_rsvpSpeechPreflightSuccess", language),
+  retryButton: readi18nPhrases("T_rsvpSpeechPreflightRetry", language),
+  failures: {
+    permissionDenied: readi18nPhrases(
+      "T_rsvpSpeechPreflightPermissionDenied",
+      language,
+    ),
+    permissionTimeout: readi18nPhrases(
+      "T_rsvpSpeechPreflightPermissionTimeout",
+      language,
+    ),
+    microphoneNotFound: readi18nPhrases(
+      "T_rsvpSpeechPreflightMicrophoneNotFound",
+      language,
+    ),
+    microphoneUnavailable: readi18nPhrases(
+      "T_rsvpSpeechPreflightMicrophoneUnavailable",
+      language,
+    ),
+    ambiguousInput: readi18nPhrases(
+      "T_rsvpSpeechPreflightAmbiguousInput",
+      language,
+    ),
+    voiceNotDetected: readi18nPhrases(
+      "T_rsvpSpeechPreflightVoiceNotDetected",
+      language,
+    ),
+    clippedInput: readi18nPhrases(
+      "T_rsvpSpeechPreflightClippedInput",
+      language,
+    ),
+    unexpected: readi18nPhrases(
+      "T_rsvpSpeechPreflightUnexpectedError",
+      language,
+    ),
+  },
+});
+
+export const runSpeechPreflight = async ({
+  signal,
+  onPhaseChange,
+  runtime,
+  openMicrophone: acquireMicrophone = openMicrophone,
+  now = () => performance.now(),
+  wait = defaultWait,
+}: RunSpeechPreflightOptions = {}): Promise<SpeechPreflightResult> => {
+  const config = { ...DEFAULT_RUNTIME_OPTIONS, ...runtime };
+  let session: MicrophoneSession | undefined;
+
+  try {
+    throwIfAborted(signal);
+    onPhaseChange?.("requestingPermission");
+    const request = acquireMicrophone({
+      audioConstraints: DEFAULT_SPEECH_AUDIO_CONSTRAINTS,
+      permissionTimeoutMs: config.permissionTimeoutMs,
+    });
+    session = await waitForMicrophone(request, signal);
+    assertUsableTrack(session);
+
+    const frame = new Float32Array(session.frameSize);
+    const ambientLevels: number[] = [];
+    let ambientZeroRatioTotal = 0;
+    let ambientFrameCount = 0;
+
+    onPhaseChange?.("measuringAmbient");
+    const ambientStartedAt = now();
+    do {
+      throwIfAborted(signal);
+      assertUsableTrack(session);
+      session.readFrame(frame);
+      const metrics = calculateAudioSignalMetrics(frame);
+      ambientLevels.push(metrics.acRms);
+      ambientZeroRatioTotal += metrics.zeroSampleRatio;
+      ambientFrameCount += 1;
+      await wait(config.pollIntervalMs, signal);
+    } while (now() - ambientStartedAt < config.ambientDurationMs);
+
+    const noiseFloorAcRms = percentile(ambientLevels, 0.8);
+    const vad = new EnergyVoiceActivityDetector({
+      initialNoiseFloorRms: noiseFloorAcRms,
+      absoluteSpeechFloorRms: config.absoluteSpeechFloorAcRms,
+      speechThresholdDbAboveNoise: config.speechThresholdDbAboveNoise,
+      minimumSpeechDurationMs: config.minimumVoiceDurationMs,
+      endOfSpeechSilenceMs: 300,
+      noiseFloorTimeConstantMs: 2000,
+    });
+
+    onPhaseChange?.("waitingForVoice");
+    const voiceStartedAt = now();
+    let maximumVoiceAcRms = 0;
+    let maximumClippedSampleRatio = 0;
+
+    do {
+      throwIfAborted(signal);
+      assertUsableTrack(session);
+      session.readFrame(frame);
+      const timestampMs = now() - voiceStartedAt;
+      const decision = vad.process(frame, timestampMs);
+      maximumVoiceAcRms = Math.max(maximumVoiceAcRms, decision.signal.acRms);
+      maximumClippedSampleRatio = Math.max(
+        maximumClippedSampleRatio,
+        decision.signal.clippedSampleRatio,
+      );
+
+      if (decision.speechStarted) {
+        if (maximumClippedSampleRatio > config.maximumClippedSampleRatio) {
+          return { ok: false, code: "clippedInput" };
+        }
+        return {
+          ok: true,
+          sampleRate: session.sampleRate,
+          frameDurationMs: session.frameDurationMs,
+          noiseFloorAcRms,
+          detectedVoiceAcRms: maximumVoiceAcRms,
+        };
+      }
+      await wait(config.pollIntervalMs, signal);
+    } while (now() - voiceStartedAt < config.voiceTimeoutMs);
+
+    const averageAmbientZeroRatio =
+      ambientFrameCount === 0 ? 1 : ambientZeroRatioTotal / ambientFrameCount;
+    return {
+      ok: false,
+      code:
+        averageAmbientZeroRatio >= 0.999 && maximumVoiceAcRms === 0
+          ? "ambiguousInput"
+          : "voiceNotDetected",
+    };
+  } catch (error) {
+    if (error instanceof SpeechPreflightCancelledError) throw error;
+    return { ok: false, code: mapFailure(error) };
+  } finally {
+    await session?.close();
+  }
+};
+
+interface ActivePreflightController {
+  cancel: () => void;
+}
+
+let activeController: ActivePreflightController | undefined;
+
+const setMessage = (
+  element: HTMLElement,
+  message: string,
+  isError = false,
+): void => {
+  element.textContent = message;
+  element.setAttribute("role", isError ? "alert" : "status");
+  element.setAttribute("aria-live", isError ? "assertive" : "polite");
+};
+
+export const mountRsvpSpeechPreflight = ({
+  block,
+  language,
+  onPassed,
+  copy = readRsvpSpeechPreflightCopy(language),
+  runPreflight = runSpeechPreflight,
+}: MountRsvpSpeechPreflightOptions): HTMLElement => {
+  activeController?.cancel();
+  document.getElementById(PREFLIGHT_ELEMENT_ID)?.remove();
+
+  const container = document.createElement("section");
+  container.id = PREFLIGHT_ELEMENT_ID;
+  container.className = "rsvp-speech-preflight";
+
+  const message = document.createElement("p");
+  message.id = "rsvp-speech-preflight-message";
+  message.className = "rsvp-speech-preflight__message";
+  setMessage(message, copy.introduction);
+  container.setAttribute("aria-labelledby", message.id);
+
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className =
+    "threshold-button threshold-proceed-button rsvp-speech-preflight__button";
+  button.textContent = copy.startButton;
+
+  container.append(message, button);
+  document.body.appendChild(container);
+
+  rsvpSpeechPreflight.required = true;
+  rsvpSpeechPreflight.status = "ready";
+  rsvpSpeechPreflight.block = block;
+  rsvpSpeechPreflight.lastFailureCode = undefined;
+
+  let runAbortController: AbortController | undefined;
+  let cancelled = false;
+  const handlePageHide = (): void => controller.cancel();
+
+  const controller: ActivePreflightController = {
+    cancel: () => {
+      if (cancelled) return;
+      cancelled = true;
+      runAbortController?.abort();
+      window.removeEventListener("pagehide", handlePageHide);
+      container.remove();
+      if (!rsvpSpeechPreflight.completed) {
+        rsvpSpeechPreflight.required = false;
+        rsvpSpeechPreflight.status = "cancelled";
+      }
+      if (activeController === controller) activeController = undefined;
+    },
+  };
+  activeController = controller;
+  window.addEventListener("pagehide", handlePageHide, { once: true });
+
+  button.onclick = async (event): Promise<void> => {
+    event.preventDefault();
+    event.stopImmediatePropagation();
+    event.stopPropagation();
+    if (cancelled || rsvpSpeechPreflight.status === "running") return;
+
+    runAbortController = new AbortController();
+    rsvpSpeechPreflight.status = "running";
+    rsvpSpeechPreflight.lastFailureCode = undefined;
+    button.disabled = true;
+
+    try {
+      const result = await runPreflight({
+        signal: runAbortController.signal,
+        onPhaseChange: (phase) => {
+          if (cancelled) return;
+          const phaseMessage: Record<SpeechPreflightPhase, string> = {
+            requestingPermission: copy.requestingPermission,
+            measuringAmbient: copy.measuringAmbient,
+            waitingForVoice: copy.waitingForVoice,
+          };
+          setMessage(message, phaseMessage[phase]);
+        },
+      });
+      if (cancelled) return;
+
+      if (!result.ok) {
+        rsvpSpeechPreflight.status = "failed";
+        rsvpSpeechPreflight.lastFailureCode = result.code;
+        setMessage(message, copy.failures[result.code], true);
+        button.textContent = copy.retryButton;
+        button.disabled = false;
+        button.focus();
+        return;
+      }
+
+      rsvpSpeechPreflight.completed = true;
+      rsvpSpeechPreflight.required = false;
+      rsvpSpeechPreflight.status = "passed";
+      setMessage(message, copy.success);
+      window.removeEventListener("pagehide", handlePageHide);
+      container.remove();
+      activeController = undefined;
+      onPassed();
+    } catch (error) {
+      if (error instanceof SpeechPreflightCancelledError || cancelled) return;
+      rsvpSpeechPreflight.status = "failed";
+      rsvpSpeechPreflight.lastFailureCode = "unexpected";
+      setMessage(message, copy.failures.unexpected, true);
+      button.textContent = copy.retryButton;
+      button.disabled = false;
+      button.focus();
+    }
+  };
+
+  button.focus();
+  return container;
+};
+
+export const cancelActiveRsvpSpeechPreflight = (): void => {
+  activeController?.cancel();
+};
+
+export const isRsvpSpeechPreflightBlocking = (): boolean =>
+  rsvpSpeechPreflight.required && !rsvpSpeechPreflight.completed;
+
+export const isAutomaticSpeechResponseEnabledForBlock = (
+  reader: { read: (name: string, block: number) => unknown[] },
+  block: number,
+): boolean =>
+  reader
+    .read("responseSpokenBool", block)
+    .some((value) => value === true || String(value).toLowerCase() === "true");

--- a/components/speech/vad.ts
+++ b/components/speech/vad.ts
@@ -1,0 +1,167 @@
+import {
+  calculateAudioSignalMetrics,
+  type AudioSignalMetrics,
+} from "./audioSignal";
+
+export type VoiceActivityState = "silence" | "speech";
+
+export interface EnergyVadConfig {
+  initialNoiseFloorRms: number;
+  absoluteSpeechFloorRms: number;
+  speechThresholdDbAboveNoise: number;
+  minimumSpeechDurationMs: number;
+  endOfSpeechSilenceMs: number;
+  noiseFloorTimeConstantMs: number;
+}
+
+export interface VoiceActivityDecision {
+  state: VoiceActivityState;
+  speechStarted: boolean;
+  speechEnded: boolean;
+  timestampMs: number;
+  noiseFloorRms: number;
+  speechThresholdRms: number;
+  signal: AudioSignalMetrics;
+}
+
+const validateConfig = (config: EnergyVadConfig): void => {
+  const nonNegativeFields: Array<keyof EnergyVadConfig> = [
+    "initialNoiseFloorRms",
+    "absoluteSpeechFloorRms",
+    "speechThresholdDbAboveNoise",
+    "minimumSpeechDurationMs",
+    "endOfSpeechSilenceMs",
+    "noiseFloorTimeConstantMs",
+  ];
+
+  for (const field of nonNegativeFields) {
+    const value = config[field];
+    if (!Number.isFinite(value) || value < 0) {
+      throw new RangeError(`${field} must be a finite non-negative number.`);
+    }
+  }
+
+  if (config.noiseFloorTimeConstantMs === 0) {
+    throw new RangeError("noiseFloorTimeConstantMs must be greater than zero.");
+  }
+};
+
+export class EnergyVoiceActivityDetector {
+  private readonly config: EnergyVadConfig;
+  private noiseFloorRms: number;
+  private state: VoiceActivityState = "silence";
+  private aboveThresholdSinceMs?: number;
+  private belowThresholdSinceMs?: number;
+  private lastTimestampMs?: number;
+
+  constructor(config: EnergyVadConfig) {
+    validateConfig(config);
+    this.config = { ...config };
+    this.noiseFloorRms = config.initialNoiseFloorRms;
+  }
+
+  calibrateNoise(samples: Float32Array): AudioSignalMetrics {
+    if (this.state === "speech") {
+      throw new Error("Noise calibration cannot run while speech is active.");
+    }
+
+    const signal = calculateAudioSignalMetrics(samples);
+    this.noiseFloorRms = signal.acRms;
+    this.aboveThresholdSinceMs = undefined;
+    this.belowThresholdSinceMs = undefined;
+    return signal;
+  }
+
+  process(samples: Float32Array, timestampMs: number): VoiceActivityDecision {
+    if (!Number.isFinite(timestampMs)) {
+      throw new RangeError("VAD timestamp must be finite.");
+    }
+    if (
+      this.lastTimestampMs !== undefined &&
+      timestampMs < this.lastTimestampMs
+    ) {
+      throw new RangeError("VAD timestamps must be monotonic.");
+    }
+    const elapsedMs =
+      this.lastTimestampMs === undefined
+        ? 0
+        : timestampMs - this.lastTimestampMs;
+    this.lastTimestampMs = timestampMs;
+
+    const signal = calculateAudioSignalMetrics(samples);
+    const thresholdRms = this.getSpeechThresholdRms();
+    const aboveThreshold = signal.acRms >= thresholdRms;
+    let speechStarted = false;
+    let speechEnded = false;
+
+    if (this.state === "silence") {
+      this.belowThresholdSinceMs = undefined;
+
+      if (aboveThreshold) {
+        this.aboveThresholdSinceMs ??= timestampMs;
+        if (
+          timestampMs - this.aboveThresholdSinceMs >=
+          this.config.minimumSpeechDurationMs
+        ) {
+          this.state = "speech";
+          this.aboveThresholdSinceMs = undefined;
+          speechStarted = true;
+        }
+      } else {
+        this.aboveThresholdSinceMs = undefined;
+        this.updateNoiseFloor(signal.acRms, elapsedMs);
+      }
+    } else if (aboveThreshold) {
+      this.belowThresholdSinceMs = undefined;
+    } else {
+      this.belowThresholdSinceMs ??= timestampMs;
+      if (
+        timestampMs - this.belowThresholdSinceMs >=
+        this.config.endOfSpeechSilenceMs
+      ) {
+        this.state = "silence";
+        this.belowThresholdSinceMs = undefined;
+        speechEnded = true;
+      }
+    }
+
+    return {
+      state: this.state,
+      speechStarted,
+      speechEnded,
+      timestampMs,
+      noiseFloorRms: this.noiseFloorRms,
+      speechThresholdRms: thresholdRms,
+      signal,
+    };
+  }
+
+  reset(initialNoiseFloorRms = this.config.initialNoiseFloorRms): void {
+    if (!Number.isFinite(initialNoiseFloorRms) || initialNoiseFloorRms < 0) {
+      throw new RangeError(
+        "initialNoiseFloorRms must be a finite non-negative number.",
+      );
+    }
+
+    this.noiseFloorRms = initialNoiseFloorRms;
+    this.state = "silence";
+    this.aboveThresholdSinceMs = undefined;
+    this.belowThresholdSinceMs = undefined;
+    this.lastTimestampMs = undefined;
+  }
+
+  private getSpeechThresholdRms(): number {
+    const relativeThreshold =
+      this.noiseFloorRms *
+      Math.pow(10, this.config.speechThresholdDbAboveNoise / 20);
+    return Math.max(this.config.absoluteSpeechFloorRms, relativeThreshold);
+  }
+
+  private updateNoiseFloor(observedRms: number, elapsedMs: number): void {
+    if (elapsedMs <= 0) return;
+
+    const alpha =
+      1 - Math.exp(-elapsedMs / this.config.noiseFloorTimeConstantMs);
+    this.noiseFloorRms = alpha * observedRms + (1 - alpha) * this.noiseFloorRms;
+  }
+}

--- a/tests/audioSignal.test.ts
+++ b/tests/audioSignal.test.ts
@@ -1,0 +1,67 @@
+import { calculateAudioSignalMetrics } from "../components/speech/audioSignal";
+
+describe("calculateAudioSignalMetrics", () => {
+  it("reports a silent frame without producing NaN values", () => {
+    const metrics = calculateAudioSignalMetrics(new Float32Array(8));
+
+    expect(metrics).toEqual({
+      sampleCount: 8,
+      rms: 0,
+      rmsDbfs: Number.NEGATIVE_INFINITY,
+      acRms: 0,
+      acRmsDbfs: Number.NEGATIVE_INFINITY,
+      peak: 0,
+      dcOffset: 0,
+      zeroSampleRatio: 1,
+      clippedSampleRatio: 0,
+    });
+  });
+
+  it("calculates level, offset, zero, and clipping metrics", () => {
+    const metrics = calculateAudioSignalMetrics(
+      new Float32Array([1, -1, 0, 0]),
+    );
+
+    expect(metrics.sampleCount).toBe(4);
+    expect(metrics.rms).toBeCloseTo(Math.sqrt(0.5));
+    expect(metrics.rmsDbfs).toBeCloseTo(20 * Math.log10(Math.sqrt(0.5)));
+    expect(metrics.acRms).toBeCloseTo(Math.sqrt(0.5));
+    expect(metrics.acRmsDbfs).toBeCloseTo(20 * Math.log10(Math.sqrt(0.5)));
+    expect(metrics.peak).toBe(1);
+    expect(metrics.dcOffset).toBe(0);
+    expect(metrics.zeroSampleRatio).toBe(0.5);
+    expect(metrics.clippedSampleRatio).toBe(0.5);
+  });
+
+  it("separates waveform energy from a constant DC offset", () => {
+    const metrics = calculateAudioSignalMetrics(
+      new Float32Array([0.25, 0.25, 0.25, 0.25]),
+    );
+
+    expect(metrics.rms).toBeCloseTo(0.25);
+    expect(metrics.dcOffset).toBeCloseTo(0.25);
+    expect(metrics.acRms).toBe(0);
+    expect(metrics.acRmsDbfs).toBe(Number.NEGATIVE_INFINITY);
+  });
+
+  it("supports explicit zero and clipping tolerances", () => {
+    const metrics = calculateAudioSignalMetrics(
+      new Float32Array([0.0005, 0.5, 0.8]),
+      { zeroEpsilon: 0.001, clippingThreshold: 0.8 },
+    );
+
+    expect(metrics.zeroSampleRatio).toBeCloseTo(1 / 3);
+    expect(metrics.clippedSampleRatio).toBeCloseTo(1 / 3);
+  });
+
+  it("rejects invalid configuration and non-finite samples", () => {
+    expect(() =>
+      calculateAudioSignalMetrics(new Float32Array([0]), {
+        clippingThreshold: 0,
+      }),
+    ).toThrow(/clippingThreshold/);
+    expect(() =>
+      calculateAudioSignalMetrics(new Float32Array([Number.NaN])),
+    ).toThrow(/finite values/);
+  });
+});

--- a/tests/microphone.test.ts
+++ b/tests/microphone.test.ts
@@ -1,0 +1,423 @@
+import {
+  MicrophoneError,
+  openMicrophone,
+} from "../components/speech/microphone";
+
+type Listener = EventListenerOrEventListenerObject;
+
+class FakeTrack {
+  readonly kind: string;
+  enabled = true;
+  muted = false;
+  readyState: MediaStreamTrackState = "live";
+  readonly stop = jest.fn(() => {
+    this.readyState = "ended";
+  });
+
+  private readonly listeners = new Map<string, Set<Listener>>();
+  private readonly settings: MediaTrackSettings;
+
+  constructor(kind = "audio", settings: MediaTrackSettings = {}) {
+    this.kind = kind;
+    this.settings = settings;
+  }
+
+  addEventListener(type: string, listener: Listener): void {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener): void {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  getSettings(): MediaTrackSettings {
+    return { ...this.settings };
+  }
+
+  emit(type: string): void {
+    const event = { type } as Event;
+    for (const listener of this.listeners.get(type) ?? []) {
+      if (typeof listener === "function") listener(event);
+      else listener.handleEvent(event);
+    }
+  }
+}
+
+class FakeStream {
+  constructor(private readonly tracks: FakeTrack[]) {}
+
+  getAudioTracks(): MediaStreamTrack[] {
+    return this.tracks.filter(
+      (track) => track.kind === "audio",
+    ) as unknown as MediaStreamTrack[];
+  }
+
+  getTracks(): MediaStreamTrack[] {
+    return this.tracks as unknown as MediaStreamTrack[];
+  }
+}
+
+class FakeAnalyser {
+  fftSize = 2048;
+  readonly disconnect = jest.fn();
+  floatSamples = new Float32Array(this.fftSize);
+  byteSamples = new Uint8Array(this.fftSize).fill(128);
+
+  getFloatTimeDomainData(target: Float32Array): void {
+    target.set(this.floatSamples.subarray(0, target.length));
+  }
+
+  getByteTimeDomainData(target: Uint8Array): void {
+    target.set(this.byteSamples.subarray(0, target.length));
+  }
+}
+
+class FakeSource {
+  readonly connect = jest.fn();
+  readonly disconnect = jest.fn();
+}
+
+class FakeAudioContext {
+  state: AudioContextState = "suspended";
+  readonly sampleRate = 48000;
+  readonly analyser = new FakeAnalyser();
+  readonly source = new FakeSource();
+  readonly resume = jest.fn(async () => {
+    this.state = "running";
+  });
+  readonly close = jest.fn(async () => {
+    this.state = "closed";
+  });
+  readonly createMediaStreamSource = jest.fn(() => this.source);
+  readonly createAnalyser = jest.fn(() => this.analyser);
+}
+
+const asStream = (stream: FakeStream): MediaStream =>
+  stream as unknown as MediaStream;
+
+const asAudioContext = (context: FakeAudioContext): AudioContext =>
+  context as unknown as AudioContext;
+
+const namedError = (name: string): Error =>
+  Object.assign(new Error(name), { name });
+
+describe("openMicrophone", () => {
+  it("reports unsupported environments before creating an audio graph", async () => {
+    const createAudioContext = jest.fn(() =>
+      asAudioContext(new FakeAudioContext()),
+    );
+
+    await expect(openMicrophone({ createAudioContext })).rejects.toMatchObject({
+      code: "unsupported",
+    });
+    expect(createAudioContext).not.toHaveBeenCalled();
+  });
+
+  it("does not access media devices until explicitly opened", async () => {
+    const track = new FakeTrack();
+    const stream = new FakeStream([track]);
+    const getUserMedia = jest.fn(async () => asStream(stream));
+    const context = new FakeAudioContext();
+
+    expect(getUserMedia).not.toHaveBeenCalled();
+
+    await openMicrophone({
+      mediaDevices: { getUserMedia },
+      createAudioContext: () => asAudioContext(context),
+    });
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+  });
+
+  it("opens one audio track and exposes pull-based frames", async () => {
+    const track = new FakeTrack("audio", { sampleRate: 48000 });
+    const stream = new FakeStream([track]);
+    const getUserMedia = jest.fn(async () => asStream(stream));
+    const context = new FakeAudioContext();
+    context.analyser.floatSamples = new Float32Array(64).fill(0.25);
+
+    const session = await openMicrophone({
+      analyserFftSize: 64,
+      audioConstraints: { channelCount: 1 },
+      mediaDevices: { getUserMedia },
+      createAudioContext: () => asAudioContext(context),
+    });
+
+    expect(getUserMedia).toHaveBeenCalledWith({
+      audio: { channelCount: 1 },
+      video: false,
+    });
+    expect(context.resume).toHaveBeenCalledTimes(1);
+    expect(context.source.connect).toHaveBeenCalledWith(context.analyser);
+    expect(session.frameSize).toBe(64);
+    expect(session.sampleRate).toBe(48000);
+    expect(session.frameDurationMs).toBeCloseTo((64 / 48000) * 1000);
+    expect(session.getHealth().state).toBe("ready");
+    expect(session.getTrackSettings()).toEqual({ sampleRate: 48000 });
+
+    const target = new Float32Array(session.frameSize);
+    session.readFrame(target);
+    expect(Array.from(target)).toEqual(Array(64).fill(0.25));
+  });
+
+  it("publishes mute, disabled, ended, and closed health", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    const session = await openMicrophone({
+      mediaDevices: {
+        getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+      },
+      createAudioContext: () => asAudioContext(context),
+    });
+    const states: string[] = [];
+    session.subscribeToHealth((health) => states.push(health.state));
+
+    track.muted = true;
+    track.emit("mute");
+    track.muted = false;
+    track.enabled = false;
+    track.emit("unmute");
+    track.enabled = true;
+    track.readyState = "ended";
+    track.emit("ended");
+    await session.close();
+
+    expect(states).toEqual(["ready", "muted", "disabled", "ended", "closed"]);
+  });
+
+  it("isolates health-listener failures", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    const session = await openMicrophone({
+      mediaDevices: {
+        getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+      },
+      createAudioContext: () => asAudioContext(context),
+    });
+    let failingListenerCalls = 0;
+    session.subscribeToHealth(() => {
+      failingListenerCalls += 1;
+      if (failingListenerCalls > 1) throw new Error("observer failed");
+    });
+    const healthyListener = jest.fn();
+    session.subscribeToHealth(healthyListener);
+
+    track.muted = true;
+    expect(() => track.emit("mute")).not.toThrow();
+
+    expect(healthyListener).toHaveBeenLastCalledWith(
+      expect.objectContaining({ state: "muted" }),
+    );
+    await expect(session.close()).resolves.toBeUndefined();
+  });
+
+  it("closes every track and audio node exactly once", async () => {
+    const audioTrack = new FakeTrack("audio");
+    const otherTrack = new FakeTrack("video");
+    const context = new FakeAudioContext();
+    const session = await openMicrophone({
+      mediaDevices: {
+        getUserMedia: jest.fn(async () =>
+          asStream(new FakeStream([audioTrack, otherTrack])),
+        ),
+      },
+      createAudioContext: () => asAudioContext(context),
+    });
+
+    await Promise.all([session.close(), session.close()]);
+
+    expect(audioTrack.stop).toHaveBeenCalledTimes(1);
+    expect(otherTrack.stop).toHaveBeenCalledTimes(1);
+    expect(context.source.disconnect).toHaveBeenCalledTimes(1);
+    expect(context.analyser.disconnect).toHaveBeenCalledTimes(1);
+    expect(context.close).toHaveBeenCalledTimes(1);
+  });
+
+  it.each([
+    ["NotAllowedError", "permissionDenied"],
+    ["NotFoundError", "deviceNotFound"],
+    ["NotReadableError", "deviceUnavailable"],
+    ["OverconstrainedError", "constraintsUnsupported"],
+    ["UnknownError", "unexpected"],
+  ])("maps %s to %s", async (browserErrorName, expectedCode) => {
+    const getUserMedia = jest.fn(async () => {
+      throw namedError(browserErrorName);
+    });
+
+    await expect(
+      openMicrophone({
+        mediaDevices: { getUserMedia },
+        createAudioContext: () => asAudioContext(new FakeAudioContext()),
+      }),
+    ).rejects.toMatchObject({
+      name: "MicrophoneError",
+      code: expectedCode,
+    });
+  });
+
+  it("stops a stream that contains no audio track", async () => {
+    const nonAudioTrack = new FakeTrack("video");
+    const context = new FakeAudioContext();
+    const createAudioContext = jest.fn(() => asAudioContext(context));
+
+    await expect(
+      openMicrophone({
+        mediaDevices: {
+          getUserMedia: jest.fn(async () =>
+            asStream(new FakeStream([nonAudioTrack])),
+          ),
+        },
+        createAudioContext,
+      }),
+    ).rejects.toMatchObject({ code: "noAudioTrack" });
+
+    expect(nonAudioTrack.stop).toHaveBeenCalledTimes(1);
+    expect(createAudioContext).toHaveBeenCalledTimes(1);
+    expect(context.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops the stream when audio graph initialization fails", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    context.createMediaStreamSource.mockImplementation(() => {
+      throw new Error("source failed");
+    });
+
+    await expect(
+      openMicrophone({
+        mediaDevices: {
+          getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+        },
+        createAudioContext: () => asAudioContext(context),
+      }),
+    ).rejects.toMatchObject({ code: "audioGraphUnavailable" });
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(context.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("stops an acquired stream when AudioContext resume fails", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    context.resume.mockRejectedValue(new Error("resume failed"));
+
+    await expect(
+      openMicrophone({
+        mediaDevices: {
+          getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+        },
+        createAudioContext: () => asAudioContext(context),
+      }),
+    ).rejects.toMatchObject({ code: "audioGraphUnavailable" });
+
+    expect(track.stop).toHaveBeenCalledTimes(1);
+    expect(context.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to byte-domain frames when float-domain sampling is unavailable", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    context.analyser.byteSamples = new Uint8Array(64).fill(192);
+    Object.assign(context.analyser, { getFloatTimeDomainData: undefined });
+    const session = await openMicrophone({
+      analyserFftSize: 64,
+      mediaDevices: {
+        getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+      },
+      createAudioContext: () => asAudioContext(context),
+    });
+
+    const target = new Float32Array(64);
+    session.readFrame(target);
+
+    expect(Array.from(target)).toEqual(Array(64).fill(0.5));
+  });
+
+  it("rejects invalid frame sizes and reads after input end or close", async () => {
+    const track = new FakeTrack();
+    const context = new FakeAudioContext();
+    const session = await openMicrophone({
+      analyserFftSize: 64,
+      mediaDevices: {
+        getUserMedia: jest.fn(async () => asStream(new FakeStream([track]))),
+      },
+      createAudioContext: () => asAudioContext(context),
+    });
+
+    expect(() => session.readFrame(new Float32Array(32))).toThrow(
+      expect.objectContaining({ code: "invalidConfiguration" }),
+    );
+
+    track.readyState = "ended";
+    expect(() => session.readFrame(new Float32Array(64))).toThrow(
+      expect.objectContaining({ code: "inputEnded" }),
+    );
+
+    await session.close();
+    expect(() => session.readFrame(new Float32Array(64))).toThrow(
+      expect.objectContaining({ code: "sessionClosed" }),
+    );
+  });
+
+  it("validates analyser size before requesting permission", async () => {
+    const getUserMedia = jest.fn();
+
+    await expect(
+      openMicrophone({
+        analyserFftSize: 100,
+        mediaDevices: { getUserMedia },
+      }),
+    ).rejects.toBeInstanceOf(MicrophoneError);
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+
+  it("bounds an unresolved permission request and stops a late stream", async () => {
+    jest.useFakeTimers();
+    const track = new FakeTrack();
+    const stream = new FakeStream([track]);
+    const context = new FakeAudioContext();
+    let resolveMediaRequest: ((stream: MediaStream) => void) | undefined;
+    const getUserMedia = jest.fn(
+      () =>
+        new Promise<MediaStream>((resolve) => {
+          resolveMediaRequest = resolve;
+        }),
+    );
+
+    try {
+      const opening = openMicrophone({
+        permissionTimeoutMs: 100,
+        mediaDevices: { getUserMedia },
+        createAudioContext: () => asAudioContext(context),
+      });
+      const rejection = expect(opening).rejects.toMatchObject({
+        code: "permissionTimeout",
+      });
+
+      await jest.advanceTimersByTimeAsync(100);
+      await rejection;
+      expect(context.close).toHaveBeenCalledTimes(1);
+
+      resolveMediaRequest?.(asStream(stream));
+      await Promise.resolve();
+      await Promise.resolve();
+      expect(track.stop).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("validates permission timeout before requesting access", async () => {
+    const getUserMedia = jest.fn();
+
+    await expect(
+      openMicrophone({
+        permissionTimeoutMs: 0,
+        mediaDevices: { getUserMedia },
+      }),
+    ).rejects.toMatchObject({ code: "invalidConfiguration" });
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+});

--- a/tests/speechPreflight.test.ts
+++ b/tests/speechPreflight.test.ts
@@ -1,0 +1,326 @@
+/**
+ * @jest-environment jsdom
+ */
+
+jest.mock("../components/global", () => ({
+  rsvpSpeechPreflight: {
+    completed: false,
+    required: false,
+    status: "idle",
+    block: undefined,
+    lastFailureCode: undefined,
+  },
+}));
+
+import { rsvpSpeechPreflight } from "../components/global";
+import {
+  cancelActiveRsvpSpeechPreflight,
+  isAutomaticSpeechResponseEnabledForBlock,
+  isRsvpSpeechPreflightBlocking,
+  mountRsvpSpeechPreflight,
+  runSpeechPreflight,
+  type SpeechPreflightCopy,
+  type SpeechPreflightPhase,
+  type SpeechPreflightResult,
+} from "../components/speech/speechPreflight";
+import type {
+  MicrophoneHealth,
+  MicrophoneSession,
+} from "../components/speech/microphone";
+
+const alternatingFrame = (amplitude: number): Float32Array =>
+  Float32Array.from({ length: 64 }, (_, index) =>
+    index % 2 === 0 ? amplitude : -amplitude,
+  );
+
+class FakeMicrophoneSession implements MicrophoneSession {
+  readonly stream = {} as MediaStream;
+  readonly track = {} as MediaStreamTrack;
+  readonly frameSize = 64;
+  readonly sampleRate = 48000;
+  readonly frameDurationMs = (this.frameSize / this.sampleRate) * 1000;
+  readonly close = jest.fn(async () => undefined);
+
+  private readCount = 0;
+
+  constructor(
+    private readonly frameForRead: (readIndex: number) => Float32Array,
+    private health: MicrophoneHealth = {
+      state: "ready",
+      readyState: "live",
+      enabled: true,
+      muted: false,
+    },
+  ) {}
+
+  getHealth(): MicrophoneHealth {
+    return { ...this.health };
+  }
+
+  getTrackSettings(): MediaTrackSettings {
+    return { sampleRate: this.sampleRate };
+  }
+
+  readFrame(target: Float32Array): void {
+    target.set(this.frameForRead(this.readCount));
+    this.readCount += 1;
+  }
+
+  subscribeToHealth(): () => void {
+    return () => undefined;
+  }
+}
+
+const runtime = {
+  ambientDurationMs: 100,
+  voiceTimeoutMs: 300,
+  permissionTimeoutMs: 100,
+  pollIntervalMs: 50,
+  minimumVoiceDurationMs: 100,
+};
+
+const copy: SpeechPreflightCopy = {
+  introduction: "Check the microphone.",
+  startButton: "Start check",
+  requestingPermission: "Requesting permission",
+  measuringAmbient: "Stay quiet",
+  waitingForVoice: "Say a short sound",
+  success: "Microphone ready",
+  retryButton: "Try again",
+  failures: {
+    permissionDenied: "Permission denied",
+    permissionTimeout: "Permission timed out",
+    microphoneNotFound: "No microphone",
+    microphoneUnavailable: "Microphone unavailable",
+    ambiguousInput: "Input could not be verified",
+    voiceNotDetected: "Voice not detected",
+    clippedInput: "Input clipped",
+    unexpected: "Unexpected error",
+  },
+};
+
+describe("runSpeechPreflight", () => {
+  it("accepts a sustained voiced-energy change and closes the session", async () => {
+    let nowMs = 0;
+    const session = new FakeMicrophoneSession((readIndex) =>
+      readIndex < 2 ? alternatingFrame(0.001) : alternatingFrame(0.05),
+    );
+    const phases: SpeechPreflightPhase[] = [];
+
+    const result = await runSpeechPreflight({
+      runtime,
+      openMicrophone: jest.fn(async () => session),
+      now: () => nowMs,
+      wait: async (durationMs) => {
+        nowMs += durationMs;
+      },
+      onPhaseChange: (phase) => phases.push(phase),
+    });
+
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error("Expected a successful preflight result.");
+    expect(result.sampleRate).toBe(48000);
+    expect(result.noiseFloorAcRms).toBeCloseTo(0.001);
+    expect(result.detectedVoiceAcRms).toBeCloseTo(0.05);
+    expect(phases).toEqual([
+      "requestingPermission",
+      "measuringAmbient",
+      "waitingForVoice",
+    ]);
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not treat a constant DC offset as a voice", async () => {
+    let nowMs = 0;
+    const session = new FakeMicrophoneSession(() =>
+      new Float32Array(64).fill(0.1),
+    );
+
+    const result = await runSpeechPreflight({
+      runtime,
+      openMicrophone: jest.fn(async () => session),
+      now: () => nowMs,
+      wait: async (durationMs) => {
+        nowMs += durationMs;
+      },
+    });
+
+    expect(result).toEqual({ ok: false, code: "voiceNotDetected" });
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports an all-zero but otherwise healthy input as ambiguous", async () => {
+    let nowMs = 0;
+    const session = new FakeMicrophoneSession(() => new Float32Array(64));
+
+    const result = await runSpeechPreflight({
+      runtime,
+      openMicrophone: jest.fn(async () => session),
+      now: () => nowMs,
+      wait: async (durationMs) => {
+        nowMs += durationMs;
+      },
+    });
+
+    expect(result).toEqual({ ok: false, code: "ambiguousInput" });
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("rejects persistently clipped voice evidence", async () => {
+    let nowMs = 0;
+    const session = new FakeMicrophoneSession((readIndex) =>
+      readIndex < 2 ? alternatingFrame(0.001) : alternatingFrame(1),
+    );
+
+    const result = await runSpeechPreflight({
+      runtime,
+      openMicrophone: jest.fn(async () => session),
+      now: () => nowMs,
+      wait: async (durationMs) => {
+        nowMs += durationMs;
+      },
+    });
+
+    expect(result).toEqual({ ok: false, code: "clippedInput" });
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("mountRsvpSpeechPreflight", () => {
+  beforeEach(() => {
+    cancelActiveRsvpSpeechPreflight();
+    document.body.innerHTML = "";
+    rsvpSpeechPreflight.completed = false;
+    rsvpSpeechPreflight.required = false;
+    rsvpSpeechPreflight.status = "idle";
+    rsvpSpeechPreflight.block = undefined;
+    rsvpSpeechPreflight.lastFailureCode = undefined;
+  });
+
+  afterEach(() => {
+    cancelActiveRsvpSpeechPreflight();
+  });
+
+  it("advances only after a successful check", async () => {
+    const onPassed = jest.fn();
+    const runPreflight = jest.fn(
+      async ({ onPhaseChange }): Promise<SpeechPreflightResult> => {
+        onPhaseChange?.("waitingForVoice");
+        return {
+          ok: true,
+          sampleRate: 48000,
+          frameDurationMs: 20,
+          noiseFloorAcRms: 0.001,
+          detectedVoiceAcRms: 0.05,
+        };
+      },
+    );
+
+    mountRsvpSpeechPreflight({
+      block: 2,
+      language: "en-US",
+      copy,
+      onPassed,
+      runPreflight,
+    });
+
+    expect(isRsvpSpeechPreflightBlocking()).toBe(true);
+    document.querySelector<HTMLButtonElement>("button")?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onPassed).toHaveBeenCalledTimes(1);
+    expect(rsvpSpeechPreflight).toMatchObject({
+      completed: true,
+      required: false,
+      status: "passed",
+      block: 2,
+    });
+    expect(document.getElementById("rsvp-speech-preflight")).toBeNull();
+  });
+
+  it("keeps the instruction blocked and offers retry after failure", async () => {
+    const onPassed = jest.fn();
+    const runPreflight = jest.fn(
+      async (): Promise<SpeechPreflightResult> => ({
+        ok: false,
+        code: "voiceNotDetected",
+      }),
+    );
+
+    mountRsvpSpeechPreflight({
+      block: 1,
+      language: "en-US",
+      copy,
+      onPassed,
+      runPreflight,
+    });
+    document.querySelector<HTMLButtonElement>("button")?.click();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(onPassed).not.toHaveBeenCalled();
+    expect(isRsvpSpeechPreflightBlocking()).toBe(true);
+    expect(rsvpSpeechPreflight).toMatchObject({
+      status: "failed",
+      lastFailureCode: "voiceNotDetected",
+    });
+    expect(
+      document.querySelector<HTMLButtonElement>("button")?.textContent,
+    ).toBe("Try again");
+  });
+
+  it("cancels an active check without advancing the instruction", async () => {
+    const onPassed = jest.fn();
+    let receivedSignal: AbortSignal | undefined;
+    const runPreflight = jest.fn(
+      ({ signal }): Promise<SpeechPreflightResult> => {
+        receivedSignal = signal;
+        return new Promise(() => undefined);
+      },
+    );
+
+    mountRsvpSpeechPreflight({
+      block: 1,
+      language: "en-US",
+      copy,
+      onPassed,
+      runPreflight,
+    });
+    document.querySelector<HTMLButtonElement>("button")?.click();
+
+    cancelActiveRsvpSpeechPreflight();
+
+    expect(receivedSignal?.aborted).toBe(true);
+    expect(onPassed).not.toHaveBeenCalled();
+    expect(isRsvpSpeechPreflightBlocking()).toBe(false);
+    expect(rsvpSpeechPreflight.status).toBe("cancelled");
+    expect(document.getElementById("rsvp-speech-preflight")).toBeNull();
+  });
+});
+
+describe("isAutomaticSpeechResponseEnabledForBlock", () => {
+  it("recognizes parsed and serialized TRUE values", () => {
+    expect(
+      isAutomaticSpeechResponseEnabledForBlock(
+        { read: () => [false, true] },
+        1,
+      ),
+    ).toBe(true);
+    expect(
+      isAutomaticSpeechResponseEnabledForBlock(
+        { read: () => ["FALSE", "TRUE"] },
+        1,
+      ),
+    ).toBe(true);
+  });
+
+  it("leaves feature-off blocks unchanged", () => {
+    expect(
+      isAutomaticSpeechResponseEnabledForBlock(
+        { read: () => [false, "FALSE"] },
+        1,
+      ),
+    ).toBe(false);
+  });
+});

--- a/tests/vad.test.ts
+++ b/tests/vad.test.ts
@@ -1,0 +1,178 @@
+import {
+  EnergyVoiceActivityDetector,
+  type EnergyVadConfig,
+} from "../components/speech/vad";
+
+const config: EnergyVadConfig = {
+  initialNoiseFloorRms: 0.01,
+  absoluteSpeechFloorRms: 0.02,
+  speechThresholdDbAboveNoise: 6,
+  minimumSpeechDurationMs: 100,
+  endOfSpeechSilenceMs: 200,
+  noiseFloorTimeConstantMs: 500,
+};
+
+const frame = (amplitude: number): Float32Array =>
+  Float32Array.from({ length: 64 }, (_, index) =>
+    index % 2 === 0 ? amplitude : -amplitude,
+  );
+
+describe("EnergyVoiceActivityDetector", () => {
+  it("requires sustained energy before reporting speech onset", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+
+    expect(vad.process(frame(0.1), 0)).toMatchObject({
+      state: "silence",
+      speechStarted: false,
+    });
+    expect(vad.process(frame(0.1), 50)).toMatchObject({
+      state: "silence",
+      speechStarted: false,
+    });
+    expect(vad.process(frame(0.1), 100)).toMatchObject({
+      state: "speech",
+      speechStarted: true,
+      speechEnded: false,
+    });
+  });
+
+  it("keeps speech active until the configured trailing silence elapses", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+    vad.process(frame(0.1), 0);
+    vad.process(frame(0.1), 100);
+
+    expect(vad.process(frame(0), 150)).toMatchObject({
+      state: "speech",
+      speechEnded: false,
+    });
+    expect(vad.process(frame(0), 349)).toMatchObject({
+      state: "speech",
+      speechEnded: false,
+    });
+    expect(vad.process(frame(0), 350)).toMatchObject({
+      state: "silence",
+      speechEnded: true,
+    });
+  });
+
+  it("does not classify a short energy spike as speech", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+
+    vad.process(frame(0.1), 0);
+    const decision = vad.process(frame(0), 50);
+
+    expect(decision).toMatchObject({
+      state: "silence",
+      speechStarted: false,
+      speechEnded: false,
+    });
+  });
+
+  it("adapts the noise floor only while not in speech", () => {
+    const vad = new EnergyVoiceActivityDetector({
+      ...config,
+      initialNoiseFloorRms: 0.02,
+      absoluteSpeechFloorRms: 0.001,
+      noiseFloorTimeConstantMs: 100,
+    });
+
+    vad.process(frame(0.01), 0);
+    const beforeSpeech = vad.process(frame(0.01), 100);
+    const expectedNoiseFloor = (1 - Math.exp(-1)) * 0.01 + Math.exp(-1) * 0.02;
+    expect(beforeSpeech.noiseFloorRms).toBeCloseTo(expectedNoiseFloor);
+
+    vad.process(frame(0.1), 200);
+    const duringSpeech = vad.process(frame(0.1), 300);
+    expect(duringSpeech.state).toBe("speech");
+    expect(duringSpeech.noiseFloorRms).toBeCloseTo(expectedNoiseFloor);
+  });
+
+  it("adapts by elapsed time rather than the number of processed frames", () => {
+    const timeBasedConfig: EnergyVadConfig = {
+      ...config,
+      initialNoiseFloorRms: 0.02,
+      absoluteSpeechFloorRms: 0.001,
+      noiseFloorTimeConstantMs: 100,
+    };
+    const sparse = new EnergyVoiceActivityDetector(timeBasedConfig);
+    const frequent = new EnergyVoiceActivityDetector(timeBasedConfig);
+
+    sparse.process(frame(0.01), 0);
+    const sparseDecision = sparse.process(frame(0.01), 100);
+
+    frequent.process(frame(0.01), 0);
+    frequent.process(frame(0.01), 25);
+    frequent.process(frame(0.01), 50);
+    frequent.process(frame(0.01), 75);
+    const frequentDecision = frequent.process(frame(0.01), 100);
+
+    expect(frequentDecision.noiseFloorRms).toBeCloseTo(
+      sparseDecision.noiseFloorRms,
+    );
+  });
+
+  it("does not classify a constant DC offset as speech", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+    const offsetFrame = new Float32Array(64).fill(0.1);
+
+    vad.process(offsetFrame, 0);
+    const decision = vad.process(offsetFrame, 100);
+
+    expect(decision.signal.rms).toBeCloseTo(0.1);
+    expect(decision.signal.acRms).toBe(0);
+    expect(decision).toMatchObject({
+      state: "silence",
+      speechStarted: false,
+    });
+  });
+
+  it("calibrates the noise floor without creating a speech candidate", () => {
+    const vad = new EnergyVoiceActivityDetector({
+      ...config,
+      initialNoiseFloorRms: 0.02,
+    });
+
+    const signal = vad.calibrateNoise(frame(0.01));
+    const decision = vad.process(frame(0.1), 100);
+
+    expect(signal.acRms).toBeCloseTo(0.01);
+    expect(decision.noiseFloorRms).toBeCloseTo(0.01);
+    expect(decision.speechStarted).toBe(false);
+  });
+
+  it("does not allow noise calibration during active speech", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+    vad.process(frame(0.1), 0);
+    vad.process(frame(0.1), 100);
+
+    expect(() => vad.calibrateNoise(frame(0.01))).toThrow(/speech is active/);
+  });
+
+  it("reset removes pending onset and timestamp state", () => {
+    const vad = new EnergyVoiceActivityDetector(config);
+    vad.process(frame(0.1), 100);
+
+    vad.reset(0.005);
+    const decision = vad.process(frame(0.1), 0);
+
+    expect(decision).toMatchObject({
+      state: "silence",
+      speechStarted: false,
+      noiseFloorRms: 0.005,
+    });
+  });
+
+  it("rejects invalid configuration and non-monotonic timestamps", () => {
+    expect(
+      () =>
+        new EnergyVoiceActivityDetector({
+          ...config,
+          noiseFloorTimeConstantMs: 0,
+        }),
+    ).toThrow(/noiseFloorTimeConstantMs/);
+
+    const vad = new EnergyVoiceActivityDetector(config);
+    vad.process(frame(0), 10);
+    expect(() => vad.process(frame(0), 9)).toThrow(/monotonic/);
+  });
+});

--- a/threshold.js
+++ b/threshold.js
@@ -98,6 +98,7 @@ import "./components/css/popup.css";
 import "./components/css/takeABreak.css";
 import "./components/css/psychojsExtra.css";
 import "./components/css/video.css";
+import "./components/css/rsvpSpeechPreflight.css";
 
 ////
 /* -------------------------------------------------------------------------- */
@@ -203,6 +204,7 @@ import {
   imageConfig,
   targetSoundListTrialData,
   targetSoundListFiles,
+  rsvpSpeechPreflight,
 } from "./components/global.js";
 
 import {
@@ -294,6 +296,12 @@ import {
   returnOrClickProceed,
   getInstructionTextMarginPx,
 } from "./components/instructions.js";
+import {
+  cancelActiveRsvpSpeechPreflight,
+  isAutomaticSpeechResponseEnabledForBlock,
+  isRsvpSpeechPreflightBlocking,
+  mountRsvpSpeechPreflight,
+} from "./components/speech/speechPreflight.ts";
 
 import {
   getCorrectSynth,
@@ -2751,6 +2759,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
 
     if (toShowCursor()) {
       continueRoutine = false;
+      cancelActiveRsvpSpeechPreflight();
       try {
         instructions.setAutoDraw(false);
         instructions2.setAutoDraw(false);
@@ -2781,6 +2790,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
     continueRoutine = true;
 
     if (
+      !isRsvpSpeechPreflightBlocking() &&
       keypad.handler &&
       keypad.handler.inUse(status.block) &&
       _key_resp_allKeys.current
@@ -2860,6 +2870,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
       },
       rsvpReading: () => {
         if (
+          !isRsvpSpeechPreflightBlocking() &&
           canType(responseType.current) &&
           psychoJS.eventManager.getKeys({ keyList: ["return"] }).length > 0 &&
           frameN > 2
@@ -4442,6 +4453,9 @@ const experiment = (howManyBlocksAreThereInTotal) => {
       frameN = -1;
       continueRoutine = true;
       clickedContinue.current = false;
+      cancelActiveRsvpSpeechPreflight();
+      rsvpSpeechPreflight.required = false;
+      rsvpSpeechPreflight.block = undefined;
 
       const L = rc.language.value;
 
@@ -4469,6 +4483,12 @@ const experiment = (howManyBlocksAreThereInTotal) => {
         "thresholdParameter",
         status.block,
       )[0];
+
+      const shouldRunRsvpSpeechPreflight =
+        targetKind.current === "rsvpReading" &&
+        !simulateActive &&
+        !rsvpSpeechPreflight.completed &&
+        isAutomaticSpeechResponseEnabledForBlock(paramReader, status.block);
 
       // Block #1 prepends the initial sound-check instructions. snapshot.block is
       // 1-based (getBlocksTrialList), so block #1 is `=== 1`.
@@ -4734,7 +4754,8 @@ const experiment = (howManyBlocksAreThereInTotal) => {
       if (
         !document.getElementById("threshold-proceed-button") &&
         canClick(responseType.current) &&
-        targetKind.current !== "reading"
+        targetKind.current !== "reading" &&
+        !shouldRunRsvpSpeechPreflight
       )
         addProceedButton(rc.language.value, paramReader);
 
@@ -4788,6 +4809,16 @@ const experiment = (howManyBlocksAreThereInTotal) => {
           1.0,
         );
 
+      if (shouldRunRsvpSpeechPreflight) {
+        mountRsvpSpeechPreflight({
+          block: status.block,
+          language: L,
+          onPassed: () => {
+            clickedContinue.current = true;
+          },
+        });
+      }
+
       // _testPxDegConversion();
       return Scheduler.Event.NEXT;
     };
@@ -4798,7 +4829,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
       setCurrentFn("initInstructionRoutineEachFrame");
       if (customInstructionText.current.includes("#NONE")) {
         removeProceedButton();
-        return Scheduler.Event.NEXT;
+        if (!isRsvpSpeechPreflightBlocking()) return Scheduler.Event.NEXT;
       }
       return _instructionRoutineEachFrame();
     };
@@ -4807,6 +4838,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
   function initInstructionRoutineEnd() {
     return async function () {
       setCurrentFn("initInstructionRoutineEnd");
+      cancelActiveRsvpSpeechPreflight();
       instructions.setAutoDraw(false);
       conditionName.setAutoDraw(false);
       if (keypad.handler) {


### PR DESCRIPTION

This PR adds the microphone preflight foundation required for automatic spoken responses in RSVP reading experiments.

It:

- adds a browser microphone session abstraction with permission timeout handling, normalized errors, input health monitoring, audio frame access, and reliable cleanup;
- introduces audio signal metrics for RMS, AC RMS, DC offset, silence, peak level, and clipping detection;
- adds an energy-based voice activity detector with adaptive background-noise tracking;
- provides an accessible speech preflight UI that checks microphone permission, measures ambient noise, and waits for a valid voice signal;
- prevents participants from advancing while the microphone check is active;
- handles permission denial, missing or unavailable microphones, silent/ambiguous input, voice timeout, and clipped audio;
- cancels and cleans up active microphone checks when the instruction routine or experiment ends;
- enables the preflight only for RSVP reading blocks that use automatic spoken responses.


Automatic RSVP speech responses require a usable microphone before the task begins. Starting without validating microphone access and input quality can result in missing or unusable responses.

This preflight verifies that:

1. microphone access is available;
2. the input device is active;
3. ambient noise can be measured;
4. a valid voice signal can be detected;
5. the input is not persistently clipped.

## Tests

Unit tests were added for:

- audio signal metric calculation;
- microphone acquisition, health state, error mapping, and cleanup;
- voice activity detection and noise-floor adaptation;
- successful and failed preflight checks;
- clipped, silent, and ambiguous microphone input;
- retry, cancellation, and instruction-blocking behavior;
- automatic speech-response configuration detection.

## Scope

This PR provides the microphone preflight foundation only. Realtime transcription sessions and provider integrations are intentionally left for follow-up changes.