### PR TITLE
Add RSVP continuous speech controller

### DIFF
--- a/components/global.js
+++ b/components/global.js
@@ -797,6 +797,20 @@ export const rsvpSpeechPreflight = {
   lastFailureCode: undefined,
 };
 
+export const rsvpSpeechRuntime = {
+  controller: undefined,
+  status: "idle",
+  simulated: false,
+  blockCondition: undefined,
+  utteranceId: undefined,
+  result: undefined,
+  error: undefined,
+  preparationStartedAtMs: undefined,
+  readyAtMs: undefined,
+  captureStartedAtMs: undefined,
+  finalizationAllowedAtMs: undefined,
+};
+
 export const rsvpReadingTiming = {
   current: {
     startSec: undefined,

--- a/components/keypad.js
+++ b/components/keypad.js
@@ -70,7 +70,7 @@ export class KeypadHandler {
           document.dispatchEvent(new Event("skip-block"));
         } else if (
           targetKind.current === "rsvpReading" &&
-          rsvpReadingResponse.responseType !== "spoken" &&
+          rsvpReadingResponse.responseType === "silent" &&
           !(
             this.controlButtons.includes(message.response) ||
             this.controlButtons.map((s) => s.toLowerCase()).includes(response)

--- a/components/lifetime.js
+++ b/components/lifetime.js
@@ -32,6 +32,10 @@ import { readi18nPhrases } from "./readPhrases.js";
 import { renderMarkdown } from "./markdownInline.js";
 import { PsychoJS } from "../psychojs/src/core/index.js";
 import { cancelActiveRsvpSpeechPreflight } from "./speech/speechPreflight.ts";
+import {
+  closeActiveRsvpSpeechTrial,
+  hasActiveRsvpSpeechResources,
+} from "./rsvpSpeech/rsvpSpeechRuntime.ts";
 
 export async function quitPsychoJS(
   message = "",
@@ -49,6 +53,7 @@ export async function quitPsychoJS(
 
   // Clean up any lingering error dialogs before showing debrief/close screens
   cancelActiveRsvpSpeechPreflight();
+  if (hasActiveRsvpSpeechResources()) await closeActiveRsvpSpeechTrial();
   try {
     document
       .querySelectorAll(".ui-dialog, #msgDialog, #expDialog")

--- a/components/onStimulusGenerated.ts
+++ b/components/onStimulusGenerated.ts
@@ -21,6 +21,7 @@ import { getFormspreeLoggingInfoLetter } from "./misc";
 
 import type { TextStim } from "./types";
 import type { Screen_ } from "./multiple-displays/globals";
+import type { RsvpReadingResponseMode } from "./rsvpSpeech/rsvpSpeechMode";
 import type {
   LetterStimulusResults,
   RepeatedLettersStimulusResults,
@@ -252,7 +253,7 @@ export const onStimulusGeneratedRsvpReading = (
   reader: ParamReader,
   block_condition: string,
   psychoJS: PsychoJS,
-  silentResponseMode: boolean,
+  responseMode: RsvpReadingResponseMode,
   durationSec: number,
 ) => {
   if (
@@ -312,7 +313,7 @@ export const onStimulusGeneratedRsvpReading = (
     rsvpReadingResponseToReturn.identificationCategories.toString(),
   );
 
-  if (silentResponseMode) {
+  if (responseMode === "silent") {
     // Those categories that will be shown to the participant, ie used for response
     rsvpReadingResponseToReturn["screen"] = setupPhraseIdentification(
       rsvpReadingResponseToReturn.identificationCategories,
@@ -328,13 +329,6 @@ export const onStimulusGeneratedRsvpReading = (
 
   rsvpReadingTargetSetsToReturn.current =
     rsvpReadingTargetSetsToReturn.upcoming.shift();
-  const rsvpReadingResponseModality = reader.read(
-    "responseSpokenToExperimenterBool",
-    block_condition,
-  )
-    ? "spoken"
-    : "silent";
-
   updateTargetSpecs(
     {
       targetWordDurationSec: durationSec,
@@ -342,7 +336,7 @@ export const onStimulusGeneratedRsvpReading = (
         "rsvpReadingNumberOfWords",
         block_condition,
       ),
-      rsvpReadingResponseModality,
+      rsvpReadingResponseModality: responseMode,
     },
     "rsvpReading",
     reader,

--- a/components/rsvpReading.js
+++ b/components/rsvpReading.js
@@ -56,6 +56,16 @@ import { paramReader } from "../threshold";
 import { XYPxOfDeg } from "./multiple-displays/utils.ts";
 import { isFontLTR, readFontDirection } from "./fontDirection.js";
 import { readFontMetricsCharacterSet } from "../preprocess/fontPixiMetricsStringDefault";
+import {
+  getRsvpReadingQuestionResponseType,
+  isRsvpReadingAutomaticSpeechResponseMode,
+  isRsvpReadingExperimenterResponseMode,
+  isRsvpReadingMatrixResponseMode,
+} from "./rsvpSpeech/rsvpSpeechMode.ts";
+import {
+  allowRsvpSpeechProviderFinalization,
+  startRsvpSpeechCapture,
+} from "./rsvpSpeech/rsvpSpeechRuntime.ts";
 
 export class RSVPReadingTargetSet {
   constructor(
@@ -343,7 +353,9 @@ export const getThisBlockRSVPReadingWords = (reader, block) => {
         nAnswers,
         individuallyTokenizedWords,
         readingFrequencyToWordArchive[reader.read("readingCorpus", BC)],
-        rsvpReadingResponse.responseTypeForCurrentBlock[i],
+        getRsvpReadingQuestionResponseType(
+          rsvpReadingResponse.responseTypeForCurrentBlock[i],
+        ),
         "rsvpReading",
         reader.read("rsvpReadingRequireUniqueWordsBool", BC),
         readingCorpusFoils,
@@ -513,6 +525,7 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
 
   // Done showing stimuli
   if (doneShowingStimuliBool) {
+    const responseMode = rsvpReadingResponse.responseType;
     // Enforce a blank delay before showing the response screen,
     // to avoid backward masking of the last word.
     if (rsvpDelayBeforeResponseStartT === undefined) {
@@ -530,29 +543,31 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
     if (restInstructionsBool) {
       instructions.tSTart = t;
       instructions.frameNStart = frameN;
-      if (rsvpReadingResponse.responseType === "spoken") {
+      if (!isRsvpReadingMatrixResponseMode(responseMode)) {
         instructions.setText("");
       }
       instructions.setAutoDraw(true);
       restInstructionsBool = false;
-      addRevealableTargetWordsToAidSpokenScoring();
-      if (keypad.handler && keypad.handler.inUse(status.block_condition)) {
-        keypad.handler.start();
-        if (rsvpReadingResponse.responseType === "silent") {
-          const firstTargetIndex = isFontLTR(
-            readFontDirection(paramReader, status.block_condition),
-          )
-            ? 0
-            : rsvpReadingTargetSets.identificationTargetSets.length - 1;
-          const firstTargetSet =
-            rsvpReadingTargetSets.identificationTargetSets[firstTargetIndex];
-          const responseOptions = shuffle([
-            firstTargetSet.word,
-            ...firstTargetSet.foilWords,
-          ]);
-          keypad.handler.update(responseOptions);
-        } else {
-          keypad.handler.update(["up", "down"]);
+      if (!isRsvpReadingAutomaticSpeechResponseMode(responseMode)) {
+        addRevealableTargetWordsToAidSpokenScoring();
+        if (keypad.handler && keypad.handler.inUse(status.block_condition)) {
+          keypad.handler.start();
+          if (isRsvpReadingMatrixResponseMode(responseMode)) {
+            const firstTargetIndex = isFontLTR(
+              readFontDirection(paramReader, status.block_condition),
+            )
+              ? 0
+              : rsvpReadingTargetSets.identificationTargetSets.length - 1;
+            const firstTargetSet =
+              rsvpReadingTargetSets.identificationTargetSets[firstTargetIndex];
+            const responseOptions = shuffle([
+              firstTargetSet.word,
+              ...firstTargetSet.foilWords,
+            ]);
+            keypad.handler.update(responseOptions);
+          } else {
+            keypad.handler.update(["up", "down"]);
+          }
         }
       }
     }
@@ -564,7 +579,7 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
       // Ensure a small delay after the last response, so the participant sees feedback for every response
       rsvpEndRoutineAtT ??= t + 0.5;
       if (t >= rsvpEndRoutineAtT) {
-        if (rsvpReadingResponse.responseType === "spoken")
+        if (isRsvpReadingExperimenterResponseMode(responseMode))
           removeScientistKeypressFeedback();
         updateTrialCounterNumbersForRSVPReading();
         rsvpEndRoutineAtT = undefined;
@@ -576,12 +591,15 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
     showCursor();
     // Show the response screen if response modality is clicking
     if (
-      rsvpReadingResponse.responseType === "silent" &&
+      isRsvpReadingMatrixResponseMode(responseMode) &&
       !rsvpReadingResponse.displayStatus
     ) {
       showPhraseIdentification(rsvpReadingResponse.screen);
       rsvpReadingResponse.displayStatus = true;
-    } else if (!rsvpReadingResponse.displayStatus) {
+    } else if (
+      isRsvpReadingExperimenterResponseMode(responseMode) &&
+      !rsvpReadingResponse.displayStatus
+    ) {
       // Else create some subtle feedback that the scientist can use
       addScientistKeypressFeedback(
         rsvpReadingTargetSets.numberOfIdentifications,
@@ -598,6 +616,7 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
       (s) => s.status === PsychoJS.Status.NOT_STARTED,
     )
   ) {
+    const isFirstTargetSet = rsvpReadingTargetSets.past.length === 0;
     // Mark start-time for this target set
     rsvpReadingTargetSets.current.startTime = t;
     rsvpReadingTargetSets.current.stims.forEach((s) => {
@@ -610,6 +629,11 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
     // We have not tested if this frame or the next one is the more accurate measurement
     start = t;
     drawTimingBars(showTimingBarsBool.current, "target", true);
+    if (
+      isFirstTargetSet &&
+      isRsvpReadingAutomaticSpeechResponseMode(rsvpReadingResponse.responseType)
+    )
+      startRsvpSpeechCapture();
   }
 
   // If current target should be done, undraw it and update which is the current targetSet
@@ -636,6 +660,12 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
     rsvpReadingTargetSets.past[
       rsvpReadingTargetSets.past.length - 1
     ].stims.forEach((s) => (s.frameNFinishedConfirmed = frameN));
+    if (
+      typeof rsvpReadingTargetSets.current === "undefined" &&
+      rsvpReadingTargetSets.upcoming.length === 0 &&
+      isRsvpReadingAutomaticSpeechResponseMode(rsvpReadingResponse.responseType)
+    )
+      allowRsvpSpeechProviderFinalization();
   }
 
   return true;

--- a/components/rsvpSpeech/rsvpSpeechController.ts
+++ b/components/rsvpSpeech/rsvpSpeechController.ts
@@ -1,0 +1,513 @@
+import { PcmMicrophoneCapture } from "../speech/audioCapture";
+import {
+  DeepgramRealtimeTranscriber,
+  type DeepgramRealtimeTranscriberOptions,
+} from "../speech/deepgramRealtimeTranscriber";
+import {
+  ElevenLabsRealtimeTranscriber,
+  type ElevenLabsRealtimeTranscriberOptions,
+} from "../speech/elevenLabsRealtimeTranscriber";
+import { openMicrophone, type MicrophoneSession } from "../speech/microphone";
+import {
+  SpeechSession,
+  type SpeechSessionState,
+  type SpeechUtteranceResult,
+} from "../speech/speechSession";
+import {
+  createSpeechTokenProvider,
+  type SpeechProvider,
+  type SpeechTokenRequestContext,
+} from "../speech/speechToken";
+import type {
+  PcmAudioChunk,
+  StreamingTranscriber,
+} from "../speech/transcriber";
+
+export type RsvpSpeechControllerState =
+  | "idle"
+  | "preparing"
+  | "ready"
+  | "capturing"
+  | "finalizing"
+  | "completed"
+  | "failed"
+  | "closed";
+
+export type RsvpSpeechControllerErrorCode =
+  | "invalidConfiguration"
+  | "invalidState"
+  | "preparationFailed"
+  | "captureFailed"
+  | "transcriptionFailed"
+  | "closed";
+
+export class RsvpSpeechControllerError extends Error {
+  readonly code: RsvpSpeechControllerErrorCode;
+  readonly originalError?: unknown;
+
+  constructor(
+    code: RsvpSpeechControllerErrorCode,
+    message: string,
+    originalError?: unknown,
+  ) {
+    super(message);
+    this.name = "RsvpSpeechControllerError";
+    this.code = code;
+    this.originalError = originalError;
+  }
+}
+
+export interface RsvpSpeechTrialConfiguration {
+  readonly utteranceId: string;
+  readonly provider: SpeechProvider;
+  readonly targetWords: readonly string[];
+  readonly languageCode: string;
+  readonly targetKeytermBiasEnabled: boolean;
+  readonly maximumResponseDurationMs: number;
+  readonly finalizationTimeoutMs?: number;
+  readonly deepgramEndpointingMs?: number;
+  readonly requestTokenContext: () => SpeechTokenRequestContext;
+}
+
+export interface RsvpSpeechCapturePort {
+  initialize(): Promise<void>;
+  start(): void;
+  stop(): void;
+  subscribe(listener: (chunk: PcmAudioChunk) => void): () => void;
+  close(): Promise<void>;
+}
+
+export interface RsvpSpeechSessionPort {
+  readonly state: SpeechSessionState;
+  connect(): Promise<unknown>;
+  beginUtterance(utteranceId: string): Promise<SpeechUtteranceResult>;
+  pushAudio(chunk: PcmAudioChunk): boolean;
+  allowProviderFinalization(): void;
+  cancelUtterance(): void;
+  close(): Promise<void>;
+}
+
+export interface RsvpSpeechControllerDependencies {
+  readonly openMicrophone?: () => Promise<MicrophoneSession>;
+  readonly createCapture?: (
+    microphone: MicrophoneSession,
+  ) => RsvpSpeechCapturePort;
+  readonly createTranscriber?: (
+    configuration: Readonly<RsvpSpeechTrialConfiguration>,
+  ) => StreamingTranscriber;
+  readonly createSession?: (
+    transcriber: StreamingTranscriber,
+    configuration: Readonly<RsvpSpeechTrialConfiguration>,
+  ) => RsvpSpeechSessionPort;
+}
+
+const DEFAULT_DEEPGRAM_ENDPOINTING_MS = 500;
+const DEFAULT_MICROPHONE_PERMISSION_TIMEOUT_MS = 8_000;
+
+const positiveDuration = (value: number, name: string): void => {
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      `${name} must be a finite positive number.`,
+    );
+  }
+};
+
+const optionalPositiveDuration = (
+  value: number | undefined,
+  name: string,
+): void => {
+  if (value !== undefined) positiveDuration(value, name);
+};
+
+const normalizeConfiguration = (
+  configuration: RsvpSpeechTrialConfiguration,
+): Readonly<RsvpSpeechTrialConfiguration> => {
+  if (!configuration || typeof configuration !== "object") {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "An RSVP speech trial configuration is required.",
+    );
+  }
+
+  const utteranceId = configuration.utteranceId?.trim();
+  const languageCode = configuration.languageCode?.trim();
+  const targetWords = configuration.targetWords?.map((word) => word.trim());
+
+  if (!utteranceId) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP speech utterance identifier cannot be empty.",
+    );
+  }
+  if (
+    configuration.provider !== "elevenlabs" &&
+    configuration.provider !== "deepgram"
+  ) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP speech provider is not supported.",
+    );
+  }
+  if (!Array.isArray(targetWords) || targetWords.length === 0) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "An RSVP speech trial must contain at least one target word.",
+    );
+  }
+  if (targetWords.some((word) => !word)) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "RSVP speech target words cannot be empty.",
+    );
+  }
+  if (!languageCode) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP speech language code cannot be empty.",
+    );
+  }
+  if (typeof configuration.targetKeytermBiasEnabled !== "boolean") {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP speech target-keyterm policy must be a Boolean value.",
+    );
+  }
+  if (typeof configuration.requestTokenContext !== "function") {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP speech token context provider is required.",
+    );
+  }
+
+  positiveDuration(
+    configuration.maximumResponseDurationMs,
+    "maximumResponseDurationMs",
+  );
+  optionalPositiveDuration(
+    configuration.finalizationTimeoutMs,
+    "finalizationTimeoutMs",
+  );
+  optionalPositiveDuration(
+    configuration.deepgramEndpointingMs,
+    "deepgramEndpointingMs",
+  );
+
+  return Object.freeze({
+    ...configuration,
+    utteranceId,
+    languageCode,
+    targetWords: Object.freeze([...targetWords]),
+  });
+};
+
+const createDefaultTranscriber = (
+  configuration: Readonly<RsvpSpeechTrialConfiguration>,
+): StreamingTranscriber => {
+  const tokenProvider = createSpeechTokenProvider(configuration.provider, {
+    requestContext: configuration.requestTokenContext,
+  });
+  const shared = {
+    tokenProvider,
+    languageCode: configuration.languageCode,
+    keyterms: configuration.targetWords,
+    targetKeytermBiasEnabled: configuration.targetKeytermBiasEnabled,
+  };
+
+  if (configuration.provider === "elevenlabs") {
+    return new ElevenLabsRealtimeTranscriber(
+      shared satisfies ElevenLabsRealtimeTranscriberOptions,
+    );
+  }
+
+  return new DeepgramRealtimeTranscriber({
+    ...shared,
+    endpointingMs:
+      configuration.deepgramEndpointingMs ?? DEFAULT_DEEPGRAM_ENDPOINTING_MS,
+  } satisfies DeepgramRealtimeTranscriberOptions);
+};
+
+const asControllerError = (
+  code: RsvpSpeechControllerErrorCode,
+  message: string,
+  error: unknown,
+): RsvpSpeechControllerError =>
+  error instanceof RsvpSpeechControllerError
+    ? error
+    : new RsvpSpeechControllerError(code, message, error);
+
+/**
+ * Owns the speech resources for one RSVP trial. It does not start audio until
+ * the timing-sensitive RSVP routine explicitly calls startCapture().
+ */
+export class RsvpSpeechController {
+  readonly configuration: Readonly<RsvpSpeechTrialConfiguration>;
+
+  private readonly dependencies: Required<RsvpSpeechControllerDependencies>;
+  private stateValue: RsvpSpeechControllerState = "idle";
+  private failureValue?: RsvpSpeechControllerError;
+  private microphone?: MicrophoneSession;
+  private capture?: RsvpSpeechCapturePort;
+  private session?: RsvpSpeechSessionPort;
+  private unsubscribeCapture?: () => void;
+  private preparationPromise?: Promise<void>;
+  private resultPromise?: Promise<SpeechUtteranceResult>;
+  private releasePromise?: Promise<void>;
+  private closePromise?: Promise<void>;
+  private closeRequested = false;
+
+  constructor(
+    configuration: RsvpSpeechTrialConfiguration,
+    dependencies: RsvpSpeechControllerDependencies = {},
+  ) {
+    this.configuration = normalizeConfiguration(configuration);
+    this.dependencies = {
+      openMicrophone:
+        dependencies.openMicrophone ??
+        (() =>
+          openMicrophone({
+            permissionTimeoutMs: DEFAULT_MICROPHONE_PERMISSION_TIMEOUT_MS,
+          })),
+      createCapture:
+        dependencies.createCapture ??
+        ((microphone) => new PcmMicrophoneCapture(microphone)),
+      createTranscriber:
+        dependencies.createTranscriber ?? createDefaultTranscriber,
+      createSession:
+        dependencies.createSession ??
+        ((transcriber, config) =>
+          new SpeechSession(transcriber, {
+            maximumUtteranceDurationMs: config.maximumResponseDurationMs,
+            finalizationTimeoutMs: config.finalizationTimeoutMs,
+          })),
+    };
+  }
+
+  get state(): RsvpSpeechControllerState {
+    return this.stateValue;
+  }
+
+  get failure(): RsvpSpeechControllerError | undefined {
+    return this.failureValue;
+  }
+
+  prepare(): Promise<void> {
+    if (this.stateValue !== "idle") {
+      return Promise.reject(
+        new RsvpSpeechControllerError(
+          "invalidState",
+          "RSVP speech can only be prepared from its idle state.",
+        ),
+      );
+    }
+    this.stateValue = "preparing";
+    this.preparationPromise = this.performPrepare();
+    return this.preparationPromise;
+  }
+
+  startCapture(): void {
+    if (this.stateValue !== "ready" || !this.capture || !this.session) {
+      throw new RsvpSpeechControllerError(
+        "invalidState",
+        "RSVP speech capture can only start after preparation succeeds.",
+      );
+    }
+
+    let utterance: Promise<SpeechUtteranceResult> | undefined;
+    try {
+      utterance = this.session.beginUtterance(this.configuration.utteranceId);
+      this.capture.start();
+      this.stateValue = "capturing";
+      this.resultPromise = this.settleUtterance(utterance);
+      void this.resultPromise.catch(() => undefined);
+    } catch (error) {
+      try {
+        this.session.cancelUtterance();
+      } catch {
+        // Resource cleanup below still closes the provider connection.
+      }
+      void utterance?.catch(() => undefined);
+      const mapped = asControllerError(
+        "captureFailed",
+        "RSVP speech capture could not start.",
+        error,
+      );
+      this.failureValue = mapped;
+      this.stateValue = "failed";
+      void this.releaseResources();
+      throw mapped;
+    }
+  }
+
+  allowProviderFinalization(): void {
+    if (this.stateValue !== "capturing" || !this.session) {
+      throw new RsvpSpeechControllerError(
+        "invalidState",
+        "RSVP speech can only finalize after capture starts.",
+      );
+    }
+    try {
+      this.session.allowProviderFinalization();
+      this.stateValue = "finalizing";
+    } catch (error) {
+      const mapped = asControllerError(
+        "transcriptionFailed",
+        "RSVP speech finalization could not start.",
+        error,
+      );
+      this.failureValue = mapped;
+      this.stateValue = "failed";
+      void this.releaseResources();
+      throw mapped;
+    }
+  }
+
+  waitForResult(): Promise<SpeechUtteranceResult> {
+    if (!this.resultPromise) {
+      return Promise.reject(
+        new RsvpSpeechControllerError(
+          "invalidState",
+          "RSVP speech has no active utterance result.",
+        ),
+      );
+    }
+    return this.resultPromise;
+  }
+
+  close(): Promise<void> {
+    this.closeRequested = true;
+    this.closePromise ??= this.performClose();
+    return this.closePromise;
+  }
+
+  private async performPrepare(): Promise<void> {
+    try {
+      const transcriber = this.dependencies.createTranscriber(
+        this.configuration,
+      );
+      this.session = this.dependencies.createSession(
+        transcriber,
+        this.configuration,
+      );
+
+      const prepareMicrophone = async (): Promise<void> => {
+        this.microphone = await this.dependencies.openMicrophone();
+        if (this.closeRequested) {
+          throw new RsvpSpeechControllerError(
+            "closed",
+            "RSVP speech preparation was cancelled.",
+          );
+        }
+        this.capture = this.dependencies.createCapture(this.microphone);
+        await this.capture.initialize();
+      };
+      const [microphoneResult, connectionResult] = await Promise.allSettled([
+        prepareMicrophone(),
+        this.session.connect(),
+      ]);
+
+      const preparationError =
+        microphoneResult.status === "rejected"
+          ? microphoneResult.reason
+          : connectionResult.status === "rejected"
+          ? connectionResult.reason
+          : undefined;
+      if (preparationError !== undefined) throw preparationError;
+      if (this.closeRequested) {
+        throw new RsvpSpeechControllerError(
+          "closed",
+          "RSVP speech preparation was cancelled.",
+        );
+      }
+
+      this.unsubscribeCapture = this.capture!.subscribe((chunk) => {
+        this.session?.pushAudio(chunk);
+      });
+      this.stateValue = "ready";
+    } catch (error) {
+      await this.releaseResources();
+      const mapped = asControllerError(
+        this.closeRequested ? "closed" : "preparationFailed",
+        this.closeRequested
+          ? "RSVP speech preparation was cancelled."
+          : "RSVP speech preparation failed.",
+        error,
+      );
+      if (!this.closeRequested) {
+        this.failureValue = mapped;
+        this.stateValue = "failed";
+      }
+      throw mapped;
+    }
+  }
+
+  private async settleUtterance(
+    utterance: Promise<SpeechUtteranceResult>,
+  ): Promise<SpeechUtteranceResult> {
+    try {
+      const result = await utterance;
+      this.capture?.stop();
+      await this.releaseResources();
+      if (!this.closeRequested) this.stateValue = "completed";
+      return result;
+    } catch (error) {
+      await this.releaseResources();
+      const mapped = asControllerError(
+        this.closeRequested ? "closed" : "transcriptionFailed",
+        this.closeRequested
+          ? "RSVP speech was closed."
+          : "RSVP speech transcription failed.",
+        error,
+      );
+      if (!this.closeRequested) {
+        this.failureValue = mapped;
+        this.stateValue = "failed";
+      }
+      throw mapped;
+    }
+  }
+
+  private async performClose(): Promise<void> {
+    await this.preparationPromise?.catch(() => undefined);
+    if (
+      this.session &&
+      (this.stateValue === "capturing" || this.stateValue === "finalizing")
+    ) {
+      try {
+        this.session.cancelUtterance();
+      } catch {
+        // The provider may already have completed while close was requested.
+      }
+    }
+    await this.releaseResources();
+    this.stateValue = "closed";
+  }
+
+  private releaseResources(): Promise<void> {
+    this.releasePromise ??= this.performReleaseResources();
+    return this.releasePromise;
+  }
+
+  private async performReleaseResources(): Promise<void> {
+    this.unsubscribeCapture?.();
+    this.unsubscribeCapture = undefined;
+    try {
+      this.capture?.stop();
+    } catch {
+      // Continue closing the remaining resources.
+    }
+
+    const capture = this.capture;
+    const session = this.session;
+    const microphone = this.microphone;
+    this.capture = undefined;
+    this.session = undefined;
+    this.microphone = undefined;
+
+    await Promise.allSettled([
+      capture?.close(),
+      session?.close(),
+      microphone?.close(),
+    ]);
+  }
+}

--- a/components/rsvpSpeech/rsvpSpeechMode.ts
+++ b/components/rsvpSpeech/rsvpSpeechMode.ts
@@ -1,0 +1,106 @@
+export type RsvpReadingResponseMode = "silent" | "spoken" | "automaticSpeech";
+
+export interface RsvpReadingResponseModeParameters {
+  readonly responseSpokenBool: boolean;
+  readonly responseSpokenToExperimenterBool: boolean;
+}
+
+export interface RsvpReadingBlockResponseModeParameters {
+  readonly responseSpokenBool: readonly boolean[];
+  readonly responseSpokenToExperimenterBool: readonly boolean[];
+}
+
+export class RsvpReadingResponseModeConfigurationError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RsvpReadingResponseModeConfigurationError";
+  }
+}
+
+const requireBoolean = (value: unknown, parameterName: string): boolean => {
+  if (typeof value !== "boolean") {
+    throw new RsvpReadingResponseModeConfigurationError(
+      `${parameterName} must be a Boolean value for RSVP reading.`,
+    );
+  }
+  return value;
+};
+
+/**
+ * Resolves the RSVP-specific response path while preserving the existing
+ * matrix (`silent`) and human-scored (`spoken`) mode identifiers.
+ */
+export const resolveRsvpReadingResponseMode = ({
+  responseSpokenBool: rawResponseSpokenBool,
+  responseSpokenToExperimenterBool: rawResponseSpokenToExperimenterBool,
+}: RsvpReadingResponseModeParameters): RsvpReadingResponseMode => {
+  const responseSpokenBool = requireBoolean(
+    rawResponseSpokenBool,
+    "responseSpokenBool",
+  );
+  const responseSpokenToExperimenterBool = requireBoolean(
+    rawResponseSpokenToExperimenterBool,
+    "responseSpokenToExperimenterBool",
+  );
+
+  if (responseSpokenBool && responseSpokenToExperimenterBool) {
+    throw new RsvpReadingResponseModeConfigurationError(
+      "RSVP reading cannot use automatic speech recognition and human experimenter scoring at the same time.",
+    );
+  }
+
+  if (responseSpokenBool) return "automaticSpeech";
+  return responseSpokenToExperimenterBool ? "spoken" : "silent";
+};
+
+/**
+ * Resolves one mode per condition without collapsing block-level parameters
+ * into a single setting.
+ */
+export const resolveRsvpReadingBlockResponseModes = ({
+  responseSpokenBool,
+  responseSpokenToExperimenterBool,
+}: RsvpReadingBlockResponseModeParameters): RsvpReadingResponseMode[] => {
+  if (
+    !Array.isArray(responseSpokenBool) ||
+    !Array.isArray(responseSpokenToExperimenterBool)
+  ) {
+    throw new RsvpReadingResponseModeConfigurationError(
+      "RSVP reading block response parameters must be arrays.",
+    );
+  }
+  if (responseSpokenBool.length !== responseSpokenToExperimenterBool.length) {
+    throw new RsvpReadingResponseModeConfigurationError(
+      "RSVP reading block response parameters must contain one value per condition.",
+    );
+  }
+
+  return responseSpokenBool.map((automaticSpeech, index) =>
+    resolveRsvpReadingResponseMode({
+      responseSpokenBool: automaticSpeech,
+      responseSpokenToExperimenterBool: responseSpokenToExperimenterBool[index],
+    }),
+  );
+};
+
+export const isRsvpReadingMatrixResponseMode = (
+  mode: RsvpReadingResponseMode,
+): mode is "silent" => mode === "silent";
+
+export const isRsvpReadingExperimenterResponseMode = (
+  mode: RsvpReadingResponseMode,
+): mode is "spoken" => mode === "spoken";
+
+export const isRsvpReadingAutomaticSpeechResponseMode = (
+  mode: RsvpReadingResponseMode,
+): mode is "automaticSpeech" => mode === "automaticSpeech";
+
+/**
+ * The shared reading-question builder uses `spoken` to mean that no choice
+ * foils are needed. Automatic RSVP speech follows that same question policy
+ * without changing its task-level response mode.
+ */
+export const getRsvpReadingQuestionResponseType = (
+  mode: RsvpReadingResponseMode,
+): "silent" | "spoken" =>
+  isRsvpReadingMatrixResponseMode(mode) ? "silent" : "spoken";

--- a/components/rsvpSpeech/rsvpSpeechRuntime.ts
+++ b/components/rsvpSpeech/rsvpSpeechRuntime.ts
@@ -1,0 +1,407 @@
+import { rsvpSpeechRuntime } from "../global";
+import {
+  RsvpSpeechController,
+  RsvpSpeechControllerError,
+  type RsvpSpeechTrialConfiguration,
+} from "./rsvpSpeechController";
+import type {
+  SpeechProvider,
+  SpeechTokenRequestContext,
+} from "../speech/speechToken";
+import type { SpeechUtteranceResult } from "../speech/speechSession";
+
+export const RSVP_SPEECH_PARAMETER_NAMES = Object.freeze({
+  provider: "rsvpReadingSpeechProvider",
+  targetKeytermBiasEnabled: "rsvpReadingTargetKeytermBiasBool",
+  responseTimeoutSec: "rsvpReadingSpeechResponseTimeoutSec",
+});
+
+export type RsvpSpeechRuntimeStatus =
+  | "idle"
+  | "preparing"
+  | "ready"
+  | "capturing"
+  | "finalizing"
+  | "completed"
+  | "failed"
+  | "closed";
+
+interface RsvpSpeechRuntimeState {
+  controller: RsvpSpeechController | undefined;
+  status: RsvpSpeechRuntimeStatus;
+  simulated: boolean;
+  blockCondition: string | undefined;
+  utteranceId: string | undefined;
+  result: SpeechUtteranceResult | undefined;
+  error: unknown;
+  preparationStartedAtMs: number | undefined;
+  readyAtMs: number | undefined;
+  captureStartedAtMs: number | undefined;
+  finalizationAllowedAtMs: number | undefined;
+}
+
+export interface RsvpSpeechTrialSetup {
+  readonly blockCondition: string;
+  readonly trialNumber: number;
+  readonly provider: unknown;
+  readonly targetWords: readonly string[];
+  readonly experimentLanguage: string;
+  readonly targetKeytermBiasEnabled: unknown;
+  readonly maximumResponseDurationSec: unknown;
+  readonly stimulusDurationMs: number;
+  readonly requestTokenContext: () => SpeechTokenRequestContext;
+}
+
+export interface RsvpSpeechRuntimeDependencies {
+  readonly createController?: (
+    configuration: RsvpSpeechTrialConfiguration,
+  ) => RsvpSpeechController;
+  readonly now?: () => number;
+}
+
+const runtime = rsvpSpeechRuntime as RsvpSpeechRuntimeState;
+let activeResultPromise: Promise<SpeechUtteranceResult> | undefined;
+let activePageHideListener: (() => void) | undefined;
+
+const defaultNow = (): number => performance.now();
+
+const normalizeProvider = (value: unknown): SpeechProvider => {
+  if (typeof value !== "string") {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      `${RSVP_SPEECH_PARAMETER_NAMES.provider} must select ElevenLabs or Deepgram.`,
+    );
+  }
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "elevenlabs") return "elevenlabs";
+  if (normalized === "deepgram") return "deepgram";
+  throw new RsvpSpeechControllerError(
+    "invalidConfiguration",
+    `${RSVP_SPEECH_PARAMETER_NAMES.provider} must select ElevenLabs or Deepgram.`,
+  );
+};
+
+const requireBoolean = (value: unknown, name: string): boolean => {
+  if (typeof value !== "boolean") {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      `${name} must be a Boolean value.`,
+    );
+  }
+  return value;
+};
+
+const responseDurationMs = (value: unknown): number => {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      `${RSVP_SPEECH_PARAMETER_NAMES.responseTimeoutSec} must be a positive number.`,
+    );
+  }
+  return value * 1000;
+};
+
+export const resolveRsvpSpeechLanguageCode = (
+  provider: SpeechProvider,
+  experimentLanguage: string,
+): string => {
+  const normalized = experimentLanguage.trim().replace(/_/g, "-");
+  if (!normalized) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The experiment language is required for RSVP speech recognition.",
+    );
+  }
+  return provider === "elevenlabs"
+    ? normalized.split("-")[0].toLowerCase()
+    : normalized;
+};
+
+export const createRsvpSpeechUtteranceId = (
+  blockCondition: string,
+  trialNumber: number,
+  uniquePart = `${Date.now()}-${Math.random().toString(36).slice(2)}`,
+): string =>
+  `rsvp-${blockCondition.replace(
+    /[^A-Za-z0-9_-]/g,
+    "-",
+  )}-${trialNumber}-${uniquePart}`;
+
+export const buildRsvpSpeechTrialConfiguration = (
+  setup: RsvpSpeechTrialSetup,
+): RsvpSpeechTrialConfiguration => {
+  const provider = normalizeProvider(setup.provider);
+  const maximumResponseDurationMs = responseDurationMs(
+    setup.maximumResponseDurationSec,
+  );
+  if (
+    !Number.isFinite(setup.stimulusDurationMs) ||
+    setup.stimulusDurationMs <= 0
+  ) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      "The RSVP stimulus duration must be a positive number.",
+    );
+  }
+  if (maximumResponseDurationMs <= setup.stimulusDurationMs) {
+    throw new RsvpSpeechControllerError(
+      "invalidConfiguration",
+      `${RSVP_SPEECH_PARAMETER_NAMES.responseTimeoutSec} must extend beyond the RSVP stimulus sequence.`,
+    );
+  }
+
+  return {
+    utteranceId: createRsvpSpeechUtteranceId(
+      setup.blockCondition,
+      setup.trialNumber,
+    ),
+    provider,
+    targetWords: setup.targetWords,
+    languageCode: resolveRsvpSpeechLanguageCode(
+      provider,
+      setup.experimentLanguage,
+    ),
+    targetKeytermBiasEnabled: requireBoolean(
+      setup.targetKeytermBiasEnabled,
+      RSVP_SPEECH_PARAMETER_NAMES.targetKeytermBiasEnabled,
+    ),
+    maximumResponseDurationMs,
+    requestTokenContext: setup.requestTokenContext,
+  };
+};
+
+const removePageHideListener = (): void => {
+  if (activePageHideListener && typeof window !== "undefined") {
+    window.removeEventListener("pagehide", activePageHideListener);
+  }
+  activePageHideListener = undefined;
+};
+
+const installPageHideListener = (controller: RsvpSpeechController): void => {
+  removePageHideListener();
+  if (typeof window === "undefined") return;
+  activePageHideListener = () => {
+    if (runtime.controller === controller) void closeActiveRsvpSpeechTrial();
+  };
+  window.addEventListener("pagehide", activePageHideListener, { once: true });
+};
+
+const resetRuntimeForTrial = (
+  configuration: RsvpSpeechTrialConfiguration,
+  simulated: boolean,
+  blockCondition: string,
+): void => {
+  runtime.controller = undefined;
+  runtime.status = "preparing";
+  runtime.simulated = simulated;
+  runtime.blockCondition = blockCondition;
+  runtime.utteranceId = configuration.utteranceId;
+  runtime.result = undefined;
+  runtime.error = undefined;
+  runtime.preparationStartedAtMs = undefined;
+  runtime.readyAtMs = undefined;
+  runtime.captureStartedAtMs = undefined;
+  runtime.finalizationAllowedAtMs = undefined;
+  activeResultPromise = undefined;
+};
+
+export const prepareRsvpSpeechTrial = async (
+  setup: RsvpSpeechTrialSetup,
+  dependencies: RsvpSpeechRuntimeDependencies = {},
+): Promise<boolean> => {
+  await closeActiveRsvpSpeechTrial();
+  runtime.status = "preparing";
+  runtime.simulated = false;
+  runtime.blockCondition = setup.blockCondition;
+  runtime.utteranceId = undefined;
+  runtime.result = undefined;
+  runtime.error = undefined;
+  runtime.preparationStartedAtMs = undefined;
+  runtime.readyAtMs = undefined;
+  runtime.captureStartedAtMs = undefined;
+  runtime.finalizationAllowedAtMs = undefined;
+
+  let configuration: RsvpSpeechTrialConfiguration;
+  try {
+    configuration = buildRsvpSpeechTrialConfiguration(setup);
+  } catch (error) {
+    runtime.status = "failed";
+    runtime.error = error;
+    return false;
+  }
+
+  resetRuntimeForTrial(configuration, false, setup.blockCondition);
+  const now = dependencies.now ?? defaultNow;
+  runtime.preparationStartedAtMs = now();
+
+  let controller: RsvpSpeechController | undefined;
+  try {
+    controller =
+      dependencies.createController?.(configuration) ??
+      new RsvpSpeechController(configuration);
+    runtime.controller = controller;
+    installPageHideListener(controller);
+    await controller.prepare();
+    if (runtime.controller !== controller) {
+      await controller.close();
+      return false;
+    }
+    runtime.status = "ready";
+    runtime.readyAtMs = now();
+    return true;
+  } catch (error) {
+    if (runtime.controller === controller) runtime.controller = undefined;
+    removePageHideListener();
+    runtime.status = "failed";
+    runtime.error = error;
+    return false;
+  }
+};
+
+export const prepareSimulatedRsvpSpeechTrial = (
+  setup: Pick<RsvpSpeechTrialSetup, "blockCondition" | "trialNumber">,
+): void => {
+  const utteranceId = createRsvpSpeechUtteranceId(
+    setup.blockCondition,
+    setup.trialNumber,
+    "simulation",
+  );
+  resetRuntimeForTrial(
+    {
+      utteranceId,
+      provider: "deepgram",
+      targetWords: ["simulation"],
+      languageCode: "en",
+      targetKeytermBiasEnabled: false,
+      maximumResponseDurationMs: 1,
+      requestTokenContext: () => ({
+        experimentFullPath: "simulation",
+        pavloviaSessionToken: "simulation",
+      }),
+    },
+    true,
+    setup.blockCondition,
+  );
+  runtime.status = "ready";
+  runtime.readyAtMs = defaultNow();
+};
+
+const storeFailure = (error: unknown): false => {
+  runtime.status = "failed";
+  runtime.error = error;
+  removePageHideListener();
+  return false;
+};
+
+export const startRsvpSpeechCapture = (
+  now: () => number = defaultNow,
+): boolean => {
+  if (runtime.status !== "ready") return false;
+  runtime.captureStartedAtMs = now();
+
+  if (runtime.simulated) {
+    runtime.status = "capturing";
+    return true;
+  }
+  const controller = runtime.controller;
+  if (!controller) return storeFailure(new Error("RSVP speech is not ready."));
+
+  try {
+    controller.startCapture();
+    runtime.status = "capturing";
+    activeResultPromise = controller.waitForResult();
+    void activeResultPromise
+      .then((result) => {
+        if (runtime.controller !== controller) return;
+        runtime.result = result;
+        runtime.status = "completed";
+        removePageHideListener();
+      })
+      .catch((error) => {
+        if (runtime.controller === controller) storeFailure(error);
+      });
+    return true;
+  } catch (error) {
+    return storeFailure(error);
+  }
+};
+
+export const allowRsvpSpeechProviderFinalization = (
+  now: () => number = defaultNow,
+): boolean => {
+  if (runtime.status !== "capturing") return false;
+  runtime.finalizationAllowedAtMs = now();
+  if (runtime.simulated) {
+    runtime.status = "finalizing";
+    return true;
+  }
+  if (!runtime.controller) {
+    return storeFailure(new Error("RSVP speech capture is not active."));
+  }
+  try {
+    runtime.controller.allowProviderFinalization();
+    runtime.status = "finalizing";
+    return true;
+  } catch (error) {
+    return storeFailure(error);
+  }
+};
+
+export const injectRsvpSpeechTranscriptForSimulation = (
+  text: string,
+  now: () => number = defaultNow,
+): SpeechUtteranceResult => {
+  if (!runtime.simulated || !runtime.utteranceId) {
+    throw new Error("No simulated RSVP speech trial is active.");
+  }
+  if (runtime.captureStartedAtMs === undefined) {
+    throw new Error("Simulated RSVP speech capture has not started.");
+  }
+  const completedAtMs = now();
+  const result: SpeechUtteranceResult = {
+    utteranceId: runtime.utteranceId,
+    text: text.trim(),
+    committedSegments: text.trim()
+      ? [{ text: text.trim(), receivedAtMs: completedAtMs }]
+      : [],
+    startedAtMs: runtime.captureStartedAtMs,
+    completedAtMs,
+    durationMs: Math.max(0, completedAtMs - runtime.captureStartedAtMs),
+    finalizationTrigger: "manual",
+  };
+  runtime.result = result;
+  runtime.status = "completed";
+  return result;
+};
+
+export const getRsvpSpeechResult = (): SpeechUtteranceResult | undefined =>
+  runtime.result;
+
+export const hasActiveRsvpSpeechResources = (): boolean =>
+  runtime.controller !== undefined;
+
+export const closeActiveRsvpSpeechTrial = async (): Promise<void> => {
+  const controller = runtime.controller;
+  runtime.controller = undefined;
+  removePageHideListener();
+  activeResultPromise = undefined;
+  if (controller) await controller.close().catch(() => undefined);
+  if (runtime.status !== "completed" && runtime.status !== "failed") {
+    runtime.status = "closed";
+  }
+};
+
+export const clearRsvpSpeechRuntimeState = async (): Promise<void> => {
+  await closeActiveRsvpSpeechTrial();
+  runtime.controller = undefined;
+  runtime.status = "idle";
+  runtime.simulated = false;
+  runtime.blockCondition = undefined;
+  runtime.utteranceId = undefined;
+  runtime.result = undefined;
+  runtime.error = undefined;
+  runtime.preparationStartedAtMs = undefined;
+  runtime.readyAtMs = undefined;
+  runtime.captureStartedAtMs = undefined;
+  runtime.finalizationAllowedAtMs = undefined;
+};

--- a/tests/onStimulusGeneratedRsvp.test.ts
+++ b/tests/onStimulusGeneratedRsvp.test.ts
@@ -25,6 +25,7 @@ const clearPhraseIdentificationRegisters = jest.fn();
 const setupPhraseIdentification = jest.fn(() => ({
   innerHTML: "<div></div>",
 }));
+const updateTargetSpecs = jest.fn();
 
 class MockCategory {
   word: string;
@@ -42,6 +43,7 @@ beforeEach(() => {
   jest.resetModules();
   clearPhraseIdentificationRegisters.mockClear();
   setupPhraseIdentification.mockClear();
+  updateTargetSpecs.mockClear();
 
   jest.doMock("../components/response", () => ({
     __esModule: true,
@@ -75,7 +77,7 @@ beforeEach(() => {
   }));
   jest.doMock("../components/showTrialInformation", () => ({
     __esModule: true,
-    updateTargetSpecs: jest.fn(),
+    updateTargetSpecs,
   }));
   jest.doMock("../components/letter", () => ({
     __esModule: true,
@@ -136,7 +138,7 @@ describe("onStimulusGeneratedRsvpReading — per-trial state reset", () => {
       makeReader() as any,
       "1_1",
       psychoJS as any,
-      false, // silentResponseMode
+      "spoken",
       0.15,
     );
     expect(clearPhraseIdentificationRegisters).toHaveBeenCalled();
@@ -153,10 +155,46 @@ describe("onStimulusGeneratedRsvpReading — per-trial state reset", () => {
       makeReader() as any,
       "1_1",
       psychoJS as any,
-      false,
+      "spoken",
       0.15,
     );
     expect(out.rsvpReadingTargetSets.skippedDueToBadTracking).toBe(0);
     expect(out.rsvpReadingTargetSets.past).toEqual([]);
   });
+
+  it.each([
+    ["silent", true],
+    ["spoken", false],
+    ["automaticSpeech", false],
+  ] as const)(
+    "creates the choice matrix only for %s mode",
+    async (responseMode, expectsMatrix) => {
+      const { onStimulusGeneratedRsvpReading } = await import(
+        "../components/onStimulusGenerated"
+      );
+
+      onStimulusGeneratedRsvpReading(
+        makeStimulusResults() as any,
+        2,
+        0,
+        makeReader() as any,
+        "1_1",
+        psychoJS as any,
+        responseMode,
+        0.15,
+      );
+
+      expect(setupPhraseIdentification).toHaveBeenCalledTimes(
+        expectsMatrix ? 1 : 0,
+      );
+      expect(updateTargetSpecs).toHaveBeenCalledWith(
+        expect.objectContaining({
+          rsvpReadingResponseModality: responseMode,
+        }),
+        "rsvpReading",
+        expect.anything(),
+        "1_1",
+      );
+    },
+  );
 });

--- a/tests/rsvpSpeechController.test.ts
+++ b/tests/rsvpSpeechController.test.ts
@@ -1,0 +1,438 @@
+import type { MicrophoneSession } from "../components/speech/microphone";
+import { DeepgramRealtimeTranscriber } from "../components/speech/deepgramRealtimeTranscriber";
+import { ElevenLabsRealtimeTranscriber } from "../components/speech/elevenLabsRealtimeTranscriber";
+import type {
+  SpeechSessionState,
+  SpeechUtteranceResult,
+} from "../components/speech/speechSession";
+import type {
+  PcmAudioChunk,
+  StreamingTranscriber,
+} from "../components/speech/transcriber";
+import {
+  RsvpSpeechController,
+  RsvpSpeechControllerError,
+  type RsvpSpeechCapturePort,
+  type RsvpSpeechControllerDependencies,
+  type RsvpSpeechSessionPort,
+  type RsvpSpeechTrialConfiguration,
+} from "../components/rsvpSpeech/rsvpSpeechController";
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+const makeResult = (utteranceId = "1_1-1"): SpeechUtteranceResult => ({
+  utteranceId,
+  text: "cat dog fish",
+  committedSegments: [{ text: "cat dog fish", receivedAtMs: 140 }],
+  startedAtMs: 100,
+  completedAtMs: 140,
+  durationMs: 40,
+  finalizationTrigger: "providerVad",
+});
+
+const makeConfiguration = (
+  overrides: Partial<RsvpSpeechTrialConfiguration> = {},
+): RsvpSpeechTrialConfiguration => ({
+  utteranceId: "1_1-1",
+  provider: "elevenlabs",
+  targetWords: ["cat", "dog", "fish"],
+  languageCode: "en",
+  targetKeytermBiasEnabled: true,
+  maximumResponseDurationMs: 6_000,
+  finalizationTimeoutMs: 3_000,
+  requestTokenContext: () => ({
+    experimentFullPath: "owner/study",
+    pavloviaSessionToken: "session-token",
+  }),
+  ...overrides,
+});
+
+class FakeCapture implements RsvpSpeechCapturePort {
+  readonly initialize = jest.fn(async () => undefined);
+  readonly start = jest.fn(() => undefined);
+  readonly stop = jest.fn(() => undefined);
+  readonly close = jest.fn(async () => undefined);
+  private listener?: (chunk: PcmAudioChunk) => void;
+
+  subscribe(listener: (chunk: PcmAudioChunk) => void): () => void {
+    this.listener = listener;
+    return jest.fn(() => {
+      this.listener = undefined;
+    });
+  }
+
+  emit(chunk: PcmAudioChunk): void {
+    this.listener?.(chunk);
+  }
+}
+
+class FakeSession implements RsvpSpeechSessionPort {
+  state: SpeechSessionState = "idle";
+  readonly events: string[];
+  readonly connect = jest.fn(async () => {
+    this.events.push("session.connect");
+    this.state = "ready";
+    return {};
+  });
+  readonly pushAudio = jest.fn(() => true);
+  readonly allowProviderFinalization = jest.fn(() => {
+    this.events.push("session.allowProviderFinalization");
+    this.state = "finalizing";
+  });
+  readonly cancelUtterance = jest.fn(() => {
+    this.events.push("session.cancelUtterance");
+    this.state = "closed";
+    this.pending?.reject(new Error("cancelled"));
+  });
+  readonly close = jest.fn(async () => {
+    this.events.push("session.close");
+    this.state = "closed";
+  });
+  private pending?: ReturnType<typeof deferred<SpeechUtteranceResult>>;
+
+  constructor(events: string[] = []) {
+    this.events = events;
+  }
+
+  beginUtterance(utteranceId: string): Promise<SpeechUtteranceResult> {
+    this.events.push(`session.begin:${utteranceId}`);
+    this.state = "listening";
+    this.pending = deferred<SpeechUtteranceResult>();
+    return this.pending.promise;
+  }
+
+  complete(result = makeResult()): void {
+    this.state = "ready";
+    this.pending?.resolve(result);
+  }
+
+  fail(error = new Error("provider failed")): void {
+    this.state = "failed";
+    this.pending?.reject(error);
+  }
+}
+
+const makeMicrophone = () =>
+  ({
+    close: jest.fn(async () => undefined),
+  }) as unknown as MicrophoneSession;
+
+const makeHarness = (
+  overrides: {
+    microphone?: MicrophoneSession;
+    capture?: FakeCapture;
+    session?: FakeSession;
+    dependencies?: Partial<RsvpSpeechControllerDependencies>;
+  } = {},
+) => {
+  const microphone = overrides.microphone ?? makeMicrophone();
+  const capture = overrides.capture ?? new FakeCapture();
+  const session = overrides.session ?? new FakeSession();
+  const transcriber = {} as StreamingTranscriber;
+  const seenConfigurations: Readonly<RsvpSpeechTrialConfiguration>[] = [];
+  const dependencies: RsvpSpeechControllerDependencies = {
+    openMicrophone: jest.fn(async () => microphone),
+    createCapture: jest.fn(() => capture),
+    createTranscriber: jest.fn((configuration) => {
+      seenConfigurations.push(configuration);
+      return transcriber;
+    }),
+    createSession: jest.fn(() => session),
+    ...overrides.dependencies,
+  };
+
+  return {
+    microphone,
+    capture,
+    session,
+    dependencies,
+    seenConfigurations,
+  };
+};
+
+describe("RsvpSpeechController", () => {
+  it("prepares one trial while keeping the audio gate closed", async () => {
+    const harness = makeHarness();
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+
+    await controller.prepare();
+
+    expect(controller.state).toBe("ready");
+    expect(harness.capture.initialize).toHaveBeenCalledTimes(1);
+    expect(harness.capture.start).not.toHaveBeenCalled();
+    expect(harness.session.connect).toHaveBeenCalledTimes(1);
+  });
+
+  it("initializes microphone capture without waiting for provider readiness", async () => {
+    const connection = deferred<unknown>();
+    const session = new FakeSession();
+    session.connect.mockImplementationOnce(() => connection.promise);
+    const harness = makeHarness({ session });
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+
+    const preparation = controller.prepare();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(harness.capture.initialize).toHaveBeenCalledTimes(1);
+    expect(controller.state).toBe("preparing");
+    connection.resolve({});
+    await preparation;
+    expect(controller.state).toBe("ready");
+  });
+
+  it("copies only this trial's target words into immutable provider configuration", async () => {
+    const targetWords = ["cat", "dog", "fish"];
+    const harness = makeHarness();
+    const controller = new RsvpSpeechController(
+      makeConfiguration({ targetWords }),
+      harness.dependencies,
+    );
+    targetWords[0] = "changed-after-construction";
+
+    await controller.prepare();
+
+    expect(harness.seenConfigurations).toHaveLength(1);
+    expect(harness.seenConfigurations[0].targetWords).toEqual([
+      "cat",
+      "dog",
+      "fish",
+    ]);
+    expect(Object.isFrozen(harness.seenConfigurations[0].targetWords)).toBe(
+      true,
+    );
+  });
+
+  it.each([
+    ["elevenlabs", ElevenLabsRealtimeTranscriber],
+    ["deepgram", DeepgramRealtimeTranscriber],
+  ] as const)(
+    "constructs the selected %s adapter",
+    async (provider, Adapter) => {
+      const harness = makeHarness();
+      let selectedTranscriber: StreamingTranscriber | undefined;
+      const controller = new RsvpSpeechController(
+        makeConfiguration({ provider }),
+        {
+          ...harness.dependencies,
+          createTranscriber: undefined,
+          createSession: (transcriber) => {
+            selectedTranscriber = transcriber;
+            return harness.session;
+          },
+        },
+      );
+
+      await controller.prepare();
+
+      expect(selectedTranscriber).toBeInstanceOf(Adapter);
+      await controller.close();
+    },
+  );
+
+  it("starts capture synchronously after opening the utterance", async () => {
+    const events: string[] = [];
+    const capture = new FakeCapture();
+    capture.start.mockImplementation(() => {
+      events.push("capture.start");
+    });
+    const session = new FakeSession(events);
+    const harness = makeHarness({ capture, session });
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    await controller.prepare();
+
+    controller.startCapture();
+
+    expect(controller.state).toBe("capturing");
+    expect(events).toEqual([
+      "session.connect",
+      "session.begin:1_1-1",
+      "capture.start",
+    ]);
+  });
+
+  it("forwards PCM only through the active trial session", async () => {
+    const harness = makeHarness();
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    await controller.prepare();
+    controller.startCapture();
+    const chunk: PcmAudioChunk = {
+      samples: new Int16Array([1, 2, 3]),
+      sampleRate: 16_000,
+      capturedAtMs: 123,
+    };
+
+    harness.capture.emit(chunk);
+
+    expect(harness.session.pushAudio).toHaveBeenCalledWith(chunk);
+  });
+
+  it("allows finalization without stopping capture and cleans up after the result", async () => {
+    const harness = makeHarness();
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    await controller.prepare();
+    controller.startCapture();
+
+    controller.allowProviderFinalization();
+
+    expect(controller.state).toBe("finalizing");
+    expect(harness.capture.stop).not.toHaveBeenCalled();
+    harness.session.complete();
+    await expect(controller.waitForResult()).resolves.toEqual(makeResult());
+    expect(controller.state).toBe("completed");
+    expect(harness.capture.close).toHaveBeenCalledTimes(1);
+    expect(harness.session.close).toHaveBeenCalledTimes(1);
+    expect(harness.microphone.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes every acquired resource when preparation fails", async () => {
+    const microphone = makeMicrophone();
+    const capture = new FakeCapture();
+    const session = new FakeSession();
+    session.connect.mockRejectedValueOnce(new Error("connection failed"));
+    const harness = makeHarness({ microphone, capture, session });
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+
+    await expect(controller.prepare()).rejects.toMatchObject({
+      code: "preparationFailed",
+    });
+
+    expect(controller.state).toBe("failed");
+    expect(capture.start).not.toHaveBeenCalled();
+    expect(session.close).toHaveBeenCalledTimes(1);
+    expect(microphone.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("turns a capture-start failure into a terminal technical failure", async () => {
+    const capture = new FakeCapture();
+    capture.start.mockImplementationOnce(() => {
+      throw new Error("capture failed");
+    });
+    const harness = makeHarness({ capture });
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    await controller.prepare();
+
+    expect(() => controller.startCapture()).toThrow(RsvpSpeechControllerError);
+    expect(controller.state).toBe("failed");
+    expect(controller.failure?.code).toBe("captureFailed");
+    expect(harness.session.cancelUtterance).toHaveBeenCalledTimes(1);
+  });
+
+  it("reports provider failure separately from a participant response", async () => {
+    const harness = makeHarness();
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    await controller.prepare();
+    controller.startCapture();
+
+    harness.session.fail();
+
+    await expect(controller.waitForResult()).rejects.toMatchObject({
+      code: "transcriptionFailed",
+    });
+    expect(controller.state).toBe("failed");
+    expect(harness.capture.close).toHaveBeenCalledTimes(1);
+    expect(harness.session.close).toHaveBeenCalledTimes(1);
+    expect(harness.microphone.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for late preparation resources and closes them on cancellation", async () => {
+    const microphoneRequest = deferred<MicrophoneSession>();
+    const connection = deferred<unknown>();
+    const microphone = makeMicrophone();
+    const session = new FakeSession();
+    session.connect.mockImplementationOnce(() => connection.promise);
+    const harness = makeHarness({
+      microphone,
+      session,
+      dependencies: {
+        openMicrophone: () => microphoneRequest.promise,
+      },
+    });
+    const controller = new RsvpSpeechController(
+      makeConfiguration(),
+      harness.dependencies,
+    );
+    const preparation = controller.prepare();
+
+    const firstClose = controller.close();
+    const secondClose = controller.close();
+    microphoneRequest.resolve(microphone);
+    connection.resolve({});
+
+    await expect(preparation).rejects.toMatchObject({ code: "closed" });
+    await expect(firstClose).resolves.toBeUndefined();
+    await expect(secondClose).resolves.toBeUndefined();
+    expect(controller.state).toBe("closed");
+    expect(microphone.close).toHaveBeenCalledTimes(1);
+    expect(session.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("isolates provider configuration across consecutive trial controllers", async () => {
+    const first = makeHarness();
+    const second = makeHarness();
+    const firstController = new RsvpSpeechController(
+      makeConfiguration({ utteranceId: "trial-1", targetWords: ["one"] }),
+      first.dependencies,
+    );
+    const secondController = new RsvpSpeechController(
+      makeConfiguration({ utteranceId: "trial-2", targetWords: ["two"] }),
+      second.dependencies,
+    );
+
+    await firstController.prepare();
+    await secondController.prepare();
+
+    expect(first.seenConfigurations[0].targetWords).toEqual(["one"]);
+    expect(second.seenConfigurations[0].targetWords).toEqual(["two"]);
+    await firstController.close();
+    expect(secondController.state).toBe("ready");
+    await secondController.close();
+  });
+
+  it.each([
+    ["empty utterance", { utteranceId: " " }],
+    ["empty targets", { targetWords: [] }],
+    ["blank target", { targetWords: ["cat", " "] }],
+    ["empty language", { languageCode: " " }],
+    ["invalid duration", { maximumResponseDurationMs: 0 }],
+  ])("rejects %s before acquiring resources", (_, overrides) => {
+    expect(
+      () =>
+        new RsvpSpeechController(
+          makeConfiguration(overrides as Partial<RsvpSpeechTrialConfiguration>),
+        ),
+    ).toThrow(RsvpSpeechControllerError);
+  });
+});

--- a/tests/rsvpSpeechMode.test.ts
+++ b/tests/rsvpSpeechMode.test.ts
@@ -1,0 +1,134 @@
+import {
+  RsvpReadingResponseModeConfigurationError,
+  getRsvpReadingQuestionResponseType,
+  isRsvpReadingAutomaticSpeechResponseMode,
+  isRsvpReadingExperimenterResponseMode,
+  isRsvpReadingMatrixResponseMode,
+  resolveRsvpReadingBlockResponseModes,
+  resolveRsvpReadingResponseMode,
+} from "../components/rsvpSpeech/rsvpSpeechMode";
+
+describe("resolveRsvpReadingResponseMode", () => {
+  it("preserves the existing matrix response mode", () => {
+    expect(
+      resolveRsvpReadingResponseMode({
+        responseSpokenBool: false,
+        responseSpokenToExperimenterBool: false,
+      }),
+    ).toBe("silent");
+  });
+
+  it("preserves the existing human experimenter response mode", () => {
+    expect(
+      resolveRsvpReadingResponseMode({
+        responseSpokenBool: false,
+        responseSpokenToExperimenterBool: true,
+      }),
+    ).toBe("spoken");
+  });
+
+  it("selects automatic speech recognition independently", () => {
+    expect(
+      resolveRsvpReadingResponseMode({
+        responseSpokenBool: true,
+        responseSpokenToExperimenterBool: false,
+      }),
+    ).toBe("automaticSpeech");
+  });
+
+  it("rejects simultaneous automatic and human-scored speech", () => {
+    expect(() =>
+      resolveRsvpReadingResponseMode({
+        responseSpokenBool: true,
+        responseSpokenToExperimenterBool: true,
+      }),
+    ).toThrow(RsvpReadingResponseModeConfigurationError);
+  });
+
+  it.each([
+    ["responseSpokenBool", "true", false],
+    ["responseSpokenToExperimenterBool", false, "true"],
+  ])("rejects a non-Boolean %s value", (_, responseSpoken, experimenter) => {
+    expect(() =>
+      resolveRsvpReadingResponseMode({
+        responseSpokenBool: responseSpoken as unknown as boolean,
+        responseSpokenToExperimenterBool: experimenter as unknown as boolean,
+      }),
+    ).toThrow(RsvpReadingResponseModeConfigurationError);
+  });
+});
+
+describe("resolveRsvpReadingBlockResponseModes", () => {
+  it("preserves condition order in a mixed four-condition RSVP block", () => {
+    expect(
+      resolveRsvpReadingBlockResponseModes({
+        responseSpokenBool: [false, true, false, true],
+        responseSpokenToExperimenterBool: [false, false, true, false],
+      }),
+    ).toEqual(["silent", "automaticSpeech", "spoken", "automaticSpeech"]);
+  });
+
+  it("does not retain mode state between repeated trial resolutions", () => {
+    const automaticCondition = {
+      responseSpokenBool: true,
+      responseSpokenToExperimenterBool: false,
+    };
+    const matrixCondition = {
+      responseSpokenBool: false,
+      responseSpokenToExperimenterBool: false,
+    };
+
+    expect(
+      Array.from({ length: 20 }, () =>
+        resolveRsvpReadingResponseMode(automaticCondition),
+      ),
+    ).toEqual(Array(20).fill("automaticSpeech"));
+    expect(resolveRsvpReadingResponseMode(matrixCondition)).toBe("silent");
+  });
+
+  it("rejects block parameter arrays with different condition counts", () => {
+    expect(() =>
+      resolveRsvpReadingBlockResponseModes({
+        responseSpokenBool: [false, true],
+        responseSpokenToExperimenterBool: [false],
+      }),
+    ).toThrow(RsvpReadingResponseModeConfigurationError);
+  });
+
+  it("rejects a non-Boolean condition without affecting adjacent modes", () => {
+    expect(() =>
+      resolveRsvpReadingBlockResponseModes({
+        responseSpokenBool: [false, "true", false] as unknown as boolean[],
+        responseSpokenToExperimenterBool: [false, false, true],
+      }),
+    ).toThrow(RsvpReadingResponseModeConfigurationError);
+  });
+});
+
+describe("RSVP response-mode capabilities", () => {
+  it("keeps choice foils only in the existing matrix mode", () => {
+    expect(getRsvpReadingQuestionResponseType("silent")).toBe("silent");
+    expect(getRsvpReadingQuestionResponseType("spoken")).toBe("spoken");
+    expect(getRsvpReadingQuestionResponseType("automaticSpeech")).toBe(
+      "spoken",
+    );
+  });
+
+  it("keeps matrix, human scoring, and automatic speech mutually exclusive", () => {
+    expect(isRsvpReadingMatrixResponseMode("silent")).toBe(true);
+    expect(isRsvpReadingMatrixResponseMode("spoken")).toBe(false);
+    expect(isRsvpReadingMatrixResponseMode("automaticSpeech")).toBe(false);
+
+    expect(isRsvpReadingExperimenterResponseMode("silent")).toBe(false);
+    expect(isRsvpReadingExperimenterResponseMode("spoken")).toBe(true);
+    expect(isRsvpReadingExperimenterResponseMode("automaticSpeech")).toBe(
+      false,
+    );
+
+    expect(isRsvpReadingAutomaticSpeechResponseMode("silent")).toBe(false);
+    expect(isRsvpReadingAutomaticSpeechResponseMode("spoken")).toBe(false);
+    expect(isRsvpReadingAutomaticSpeechResponseMode("automaticSpeech")).toBe(
+      true,
+    );
+  });
+});

--- a/tests/rsvpSpeechRuntime.test.ts
+++ b/tests/rsvpSpeechRuntime.test.ts
@@ -1,0 +1,203 @@
+jest.mock("../components/global", () => ({
+  rsvpSpeechRuntime: {
+    controller: undefined,
+    status: "idle",
+    simulated: false,
+    blockCondition: undefined,
+    utteranceId: undefined,
+    result: undefined,
+    error: undefined,
+    preparationStartedAtMs: undefined,
+    readyAtMs: undefined,
+    captureStartedAtMs: undefined,
+    finalizationAllowedAtMs: undefined,
+  },
+}));
+
+import { rsvpSpeechRuntime } from "../components/global";
+import type { RsvpSpeechController } from "../components/rsvpSpeech/rsvpSpeechController";
+import {
+  allowRsvpSpeechProviderFinalization,
+  buildRsvpSpeechTrialConfiguration,
+  clearRsvpSpeechRuntimeState,
+  getRsvpSpeechResult,
+  hasActiveRsvpSpeechResources,
+  injectRsvpSpeechTranscriptForSimulation,
+  prepareRsvpSpeechTrial,
+  prepareSimulatedRsvpSpeechTrial,
+  resolveRsvpSpeechLanguageCode,
+  startRsvpSpeechCapture,
+  type RsvpSpeechTrialSetup,
+} from "../components/rsvpSpeech/rsvpSpeechRuntime";
+import type { SpeechUtteranceResult } from "../components/speech/speechSession";
+
+const baseSetup = (): RsvpSpeechTrialSetup => ({
+  blockCondition: "2_3",
+  trialNumber: 7,
+  provider: "ElevenLabs",
+  targetWords: ["cat", "dog", "fish"],
+  experimentLanguage: "en-US",
+  targetKeytermBiasEnabled: true,
+  maximumResponseDurationSec: 6,
+  stimulusDurationMs: 750,
+  requestTokenContext: () => ({
+    experimentFullPath: "scientist/study",
+    pavloviaSessionToken: "session-token",
+  }),
+});
+
+const utteranceResult = (utteranceId: string): SpeechUtteranceResult => ({
+  utteranceId,
+  text: "cat dog fish",
+  committedSegments: [{ text: "cat dog fish", receivedAtMs: 40 }],
+  startedAtMs: 20,
+  completedAtMs: 40,
+  durationMs: 20,
+  finalizationTrigger: "providerVad",
+});
+
+const deferred = <T>() => {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+  return { promise, resolve, reject };
+};
+
+beforeEach(async () => {
+  await clearRsvpSpeechRuntimeState();
+});
+
+afterAll(async () => {
+  await clearRsvpSpeechRuntimeState();
+});
+
+describe("RSVP speech trial configuration", () => {
+  it("maps the experiment locale to the provider-specific language format", () => {
+    expect(resolveRsvpSpeechLanguageCode("elevenlabs", "pt-BR")).toBe("pt");
+    expect(resolveRsvpSpeechLanguageCode("deepgram", "pt_BR")).toBe("pt-BR");
+  });
+
+  it("uses only the current trial targets and converts seconds to milliseconds", () => {
+    const configuration = buildRsvpSpeechTrialConfiguration(baseSetup());
+
+    expect(configuration.provider).toBe("elevenlabs");
+    expect(configuration.targetWords).toEqual(["cat", "dog", "fish"]);
+    expect(configuration.languageCode).toBe("en");
+    expect(configuration.targetKeytermBiasEnabled).toBe(true);
+    expect(configuration.maximumResponseDurationMs).toBe(6000);
+    expect(configuration.utteranceId).toContain("rsvp-2_3-7-");
+  });
+
+  it("rejects a response timeout that could expire during presentation", () => {
+    expect(() =>
+      buildRsvpSpeechTrialConfiguration({
+        ...baseSetup(),
+        maximumResponseDurationSec: 0.5,
+      }),
+    ).toThrow("must extend beyond the RSVP stimulus sequence");
+  });
+
+  it.each([
+    ["provider", "unknown"],
+    ["targetKeytermBiasEnabled", "true"],
+    ["maximumResponseDurationSec", 0],
+  ] as const)("rejects invalid %s values", (field, value) => {
+    expect(() =>
+      buildRsvpSpeechTrialConfiguration({
+        ...baseSetup(),
+        [field]: value,
+      }),
+    ).toThrow();
+  });
+});
+
+describe("RSVP speech runtime lifecycle", () => {
+  it("prepares before capture and forwards onset/finalization exactly once", async () => {
+    const result = deferred<SpeechUtteranceResult>();
+    const prepare = jest.fn(async () => undefined);
+    const startCapture = jest.fn();
+    const allowProviderFinalization = jest.fn();
+    const waitForResult = jest.fn(() => result.promise);
+    const close = jest.fn(async () => undefined);
+    const controller = {
+      prepare,
+      startCapture,
+      allowProviderFinalization,
+      waitForResult,
+      close,
+    } as unknown as RsvpSpeechController;
+    const now = jest
+      .fn<ReturnType<() => number>, []>()
+      .mockReturnValueOnce(10)
+      .mockReturnValueOnce(15);
+
+    await expect(
+      prepareRsvpSpeechTrial(baseSetup(), {
+        createController: () => controller,
+        now,
+      }),
+    ).resolves.toBe(true);
+    expect(prepare).toHaveBeenCalledTimes(1);
+    expect(rsvpSpeechRuntime.status).toBe("ready");
+    expect(hasActiveRsvpSpeechResources()).toBe(true);
+
+    expect(startRsvpSpeechCapture(() => 20)).toBe(true);
+    expect(startCapture).toHaveBeenCalledTimes(1);
+    expect(waitForResult).toHaveBeenCalledTimes(1);
+    expect(rsvpSpeechRuntime.captureStartedAtMs).toBe(20);
+
+    expect(allowRsvpSpeechProviderFinalization(() => 30)).toBe(true);
+    expect(allowProviderFinalization).toHaveBeenCalledTimes(1);
+    expect(rsvpSpeechRuntime.finalizationAllowedAtMs).toBe(30);
+
+    result.resolve(utteranceResult(rsvpSpeechRuntime.utteranceId!));
+    await result.promise;
+    await Promise.resolve();
+    expect(rsvpSpeechRuntime.status).toBe("completed");
+    expect(getRsvpSpeechResult()?.text).toBe("cat dog fish");
+  });
+
+  it("does not open a timing gate before preparation succeeds", () => {
+    expect(hasActiveRsvpSpeechResources()).toBe(false);
+    expect(startRsvpSpeechCapture()).toBe(false);
+    expect(allowRsvpSpeechProviderFinalization()).toBe(false);
+  });
+
+  it("keeps preparation failures in speech state instead of throwing into RSVP", async () => {
+    const controller = {
+      prepare: jest.fn(async () => {
+        throw new Error("provider unavailable");
+      }),
+      close: jest.fn(async () => undefined),
+    } as unknown as RsvpSpeechController;
+
+    await expect(
+      prepareRsvpSpeechTrial(baseSetup(), {
+        createController: () => controller,
+      }),
+    ).resolves.toBe(false);
+    expect(hasActiveRsvpSpeechResources()).toBe(false);
+    expect(rsvpSpeechRuntime.status).toBe("failed");
+    expect(rsvpSpeechRuntime.error).toBeInstanceOf(Error);
+  });
+
+  it("supports transcript injection without microphone or provider access", () => {
+    prepareSimulatedRsvpSpeechTrial({
+      blockCondition: "2_3",
+      trialNumber: 7,
+    });
+    expect(startRsvpSpeechCapture(() => 100)).toBe(true);
+    expect(allowRsvpSpeechProviderFinalization(() => 120)).toBe(true);
+
+    const result = injectRsvpSpeechTranscriptForSimulation(
+      "cat dog fish",
+      () => 140,
+    );
+    expect(result.durationMs).toBe(40);
+    expect(result.text).toBe("cat dog fish");
+    expect(rsvpSpeechRuntime.status).toBe("completed");
+  });
+});

--- a/threshold.js
+++ b/threshold.js
@@ -500,6 +500,17 @@ import {
   undrawAllRSVPReadingStims,
 } from "./components/rsvpReading.js";
 import {
+  isRsvpReadingAutomaticSpeechResponseMode,
+  resolveRsvpReadingBlockResponseModes,
+  resolveRsvpReadingResponseMode,
+} from "./components/rsvpSpeech/rsvpSpeechMode.ts";
+import {
+  RSVP_SPEECH_PARAMETER_NAMES,
+  closeActiveRsvpSpeechTrial,
+  prepareRsvpSpeechTrial,
+  prepareSimulatedRsvpSpeechTrial,
+} from "./components/rsvpSpeech/rsvpSpeechRuntime.ts";
+import {
   createExperimentProgressBar,
   updateExperimentProgressBar,
   destroyExperimentProgressBar,
@@ -4602,9 +4613,17 @@ const experiment = (howManyBlocksAreThereInTotal) => {
                 .reduce((a, b) => a + b),
             );
           _instructionSetup(rsvpReadingBlockInstructs, status.block, true, 1.0);
-          rsvpReadingResponse.responseTypeForCurrentBlock = paramReader
-            .read("responseSpokenToExperimenterBool", status.block)
-            .map((x) => (x ? "spoken" : "silent"));
+          rsvpReadingResponse.responseTypeForCurrentBlock =
+            resolveRsvpReadingBlockResponseModes({
+              responseSpokenBool: paramReader.read(
+                "responseSpokenBool",
+                status.block,
+              ),
+              responseSpokenToExperimenterBool: paramReader.read(
+                "responseSpokenToExperimenterBool",
+                status.block,
+              ),
+            });
           rsvpReadingWordsForThisBlock.current = getThisBlockRSVPReadingWords(
             paramReader,
             status.block,
@@ -5109,6 +5128,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
   // Runs before every trial to set up for the trial
   function trialInstructionRoutineBegin(snapshot) {
     return async function () {
+      let rsvpSpeechPreparationPromise;
       // Publish trial metadata for the simulated participant. Inside the
       // returned async function so status.trial is already updated by
       // importConditions. No-op for real participants.
@@ -6074,12 +6094,13 @@ const experiment = (howManyBlocksAreThereInTotal) => {
           drawTimingBars(showTimingBarsBool.current, "TargetRequest", false);
           drawTimingBars(showTimingBarsBool.current, "gap", false);
 
-          rsvpReadingResponse.responseType = paramReader.read(
-            "responseSpokenToExperimenterBool",
-            BC,
-          )
-            ? "spoken"
-            : "silent";
+          rsvpReadingResponse.responseType = resolveRsvpReadingResponseMode({
+            responseSpokenBool: paramReader.read("responseSpokenBool", BC),
+            responseSpokenToExperimenterBool: paramReader.read(
+              "responseSpokenToExperimenterBool",
+              BC,
+            ),
+          });
 
           const rsvpReadingNumberOfWords = paramReader.read(
             "rsvpReadingNumberOfWords",
@@ -6160,7 +6181,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
               paramReader,
               status.block_condition,
               psychoJS,
-              rsvpReadingResponse.responseType === "silent",
+              rsvpReadingResponse.responseType,
               durationSec,
             );
 
@@ -6179,6 +6200,45 @@ const experiment = (howManyBlocksAreThereInTotal) => {
           } catch (error) {
             onStimulusGenerationFailed("rsvpReading", { error });
             return Scheduler.Event.NEXT;
+          }
+
+          if (
+            isRsvpReadingAutomaticSpeechResponseMode(
+              rsvpReadingResponse.responseType,
+            )
+          ) {
+            if (simulateActive) {
+              prepareSimulatedRsvpSpeechTrial({
+                blockCondition: status.block_condition,
+                trialNumber: Number(status.trial),
+              });
+            } else {
+              rsvpSpeechPreparationPromise = prepareRsvpSpeechTrial({
+                blockCondition: status.block_condition,
+                trialNumber: Number(status.trial),
+                provider: paramReader.read(
+                  RSVP_SPEECH_PARAMETER_NAMES.provider,
+                  status.block_condition,
+                ),
+                targetWords: thisTrialWords.targetWords,
+                experimentLanguage: rc.language.value,
+                targetKeytermBiasEnabled: paramReader.read(
+                  RSVP_SPEECH_PARAMETER_NAMES.targetKeytermBiasEnabled,
+                  status.block_condition,
+                ),
+                maximumResponseDurationSec: paramReader.read(
+                  RSVP_SPEECH_PARAMETER_NAMES.responseTimeoutSec,
+                  status.block_condition,
+                ),
+                stimulusDurationMs:
+                  thisTrialWords.screens.length * durationSec * 1000,
+                requestTokenContext: () => ({
+                  experimentFullPath:
+                    psychoJS.config?.experiment?.fullpath ?? "",
+                  pavloviaSessionToken: psychoJS.config?.session?.token ?? "",
+                }),
+              });
+            }
           }
 
           // Set up instructions
@@ -6549,6 +6609,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
         letterConfig?.thresholdParameter === "spacingDeg"
       )
         doubleCheckSizeToSpacing(target, flanker1, stimulusParameters);
+      if (rsvpSpeechPreparationPromise) await rsvpSpeechPreparationPromise;
       /* --------------------------------- \PUBLIC -------------------------------- */
       return Scheduler.Event.NEXT;
     };
@@ -7868,7 +7929,15 @@ const experiment = (howManyBlocksAreThereInTotal) => {
         // RSVP words are autoDraw stims that are normally undrawn later in this
         // per-frame loop. Skipping short-circuits that, so erase any word still
         // on screen to avoid it lingering into the next block.
-        if (targetKind.current === "rsvpReading") undrawAllRSVPReadingStims();
+        if (targetKind.current === "rsvpReading") {
+          undrawAllRSVPReadingStims();
+          if (
+            isRsvpReadingAutomaticSpeechResponseMode(
+              rsvpReadingResponse.responseType,
+            )
+          )
+            void closeActiveRsvpSpeechTrial();
+        }
         return Scheduler.Event.NEXT;
       }
 
@@ -8120,7 +8189,12 @@ const experiment = (howManyBlocksAreThereInTotal) => {
           });
           _key_resp_allKeys.current.push(...theseKeys);
 
-          if (targetKind.current === "rsvpReading")
+          if (
+            targetKind.current === "rsvpReading" &&
+            !isRsvpReadingAutomaticSpeechResponseMode(
+              rsvpReadingResponse.responseType,
+            )
+          )
             registerKeypressForRSVPReading(_key_resp_allKeys.current);
           if (targetKind.current === "repeatedLetters") {
             theseKeys.forEach((k) => {


### PR DESCRIPTION
## Summary

Adds the RSVP continuous speech controller for automatic speech responses.

## What changed

- Adds an RSVP-specific automatic speech response mode using `responseSpokenBool`.
- Prepares the microphone and STT provider before stimulus presentation.
- Starts continuous audio capture at the first RSVP target onset.
- Allows provider finalization after the final target offset.
- Suppresses the matrix, keypad, and human-scoring controls only in automatic speech mode.
- Adds cleanup for trial skip, experiment quit, and page unload.
- Adds a simulation path that does not require a microphone or STT provider.


## Testing

- TypeScript checks pass.
- RSVP speech mode, controller, runtime, and stimulus-generation tests pass.