### PR TITLE
Add RSVP speech scoring and failure safeguards

### DIFF
--- a/components/instructions.js
+++ b/components/instructions.js
@@ -130,6 +130,29 @@ const _timingInitialByThresholdParam = (
   return text;
 };
 
+const rsvpReadingAutomaticSpeechResponse = (L) => {
+  const extraSpace =
+    readi18nPhrases("EE_LanguageUsesSpacesBool", L) === "TRUE" ? " " : "";
+  return (
+    extraSpace + `${readi18nPhrases("T_rsvpSpeechReadingInstruction", L)}\n\n`
+  );
+};
+
+const rsvpReadingAutomaticSpeechBegin = (
+  L,
+  responseType = 1,
+  trialsThisBlock = 0,
+) =>
+  replacePlaceholders(
+    readi18nPhrases("T_thresholdRsvpReadingBeginBlock", L),
+    trialsThisBlock,
+  ) +
+  rsvpReadingAutomaticSpeechResponse(L) +
+  `${readi18nPhrases("T_escapeToQuit", L)} ${returnOrClickProceed(
+    L,
+    responseType,
+  )}\n\n`;
+
 export const instructionsText = {
   initial: (L) => {
     return readi18nPhrases("T_thresholdSoundCheck", L) + `\n\n`;
@@ -148,6 +171,8 @@ export const instructionsText = {
       "\n\n"
     );
   },
+  rsvpReadingAutomaticSpeechBegin,
+  rsvpReadingAutomaticSpeechResponse,
   imageBegin: (L, totalTrialsThisBlock = 0, targetTaskValue = "") => {
     if (targetTaskValue === "adjust") {
       return readi18nPhrases("T_adjustImageEccentricity", L);

--- a/components/rsvpReading.js
+++ b/components/rsvpReading.js
@@ -64,6 +64,7 @@ import {
 } from "./rsvpSpeech/rsvpSpeechMode.ts";
 import {
   allowRsvpSpeechProviderFinalization,
+  closeActiveRsvpSpeechTrial,
   startRsvpSpeechCapture,
 } from "./rsvpSpeech/rsvpSpeechRuntime.ts";
 
@@ -509,6 +510,12 @@ export const _rsvpReading_trialRoutineEachFrame = (t, frameN, instructions) => {
   if (rsvpReadingTargetSets.skippedDueToBadTracking) {
     // Set to 1 when tracking is lost
     if (rsvpReadingTargetSets.skippedDueToBadTracking === 1) {
+      if (
+        isRsvpReadingAutomaticSpeechResponseMode(
+          rsvpReadingResponse.responseType,
+        )
+      )
+        void closeActiveRsvpSpeechTrial();
       if (start !== undefined && rsvpReadingTargetSets.past.length > 0) {
         rsvpReadingTargetSets.past[
           rsvpReadingTargetSets.past.length - 1

--- a/components/rsvpSpeech/rsvpSpeechRuntime.ts
+++ b/components/rsvpSpeech/rsvpSpeechRuntime.ts
@@ -45,7 +45,7 @@ export interface RsvpSpeechTrialSetup {
   readonly trialNumber: number;
   readonly provider: unknown;
   readonly targetWords: readonly string[];
-  readonly experimentLanguage: string;
+  readonly conditionLanguage: string;
   readonly targetKeytermBiasEnabled: unknown;
   readonly maximumResponseDurationSec: unknown;
   readonly stimulusDurationMs: number;
@@ -62,6 +62,7 @@ export interface RsvpSpeechRuntimeDependencies {
 const runtime = rsvpSpeechRuntime as RsvpSpeechRuntimeState;
 let activeResultPromise: Promise<SpeechUtteranceResult> | undefined;
 let activePageHideListener: (() => void) | undefined;
+let activeClosePromise: Promise<void> | undefined;
 
 const defaultNow = (): number => performance.now();
 
@@ -101,15 +102,15 @@ const responseDurationMs = (value: unknown): number => {
   return value * 1000;
 };
 
-export const resolveRsvpSpeechLanguageCode = (
+export const resolveRsvpSpeechProviderLanguageCode = (
   provider: SpeechProvider,
-  experimentLanguage: string,
+  conditionLanguage: string,
 ): string => {
-  const normalized = experimentLanguage.trim().replace(/_/g, "-");
+  const normalized = conditionLanguage.trim().replace(/_/g, "-");
   if (!normalized) {
     throw new RsvpSpeechControllerError(
       "invalidConfiguration",
-      "The experiment language is required for RSVP speech recognition.",
+      "The condition language is required for RSVP speech recognition.",
     );
   }
   return provider === "elevenlabs"
@@ -157,9 +158,9 @@ export const buildRsvpSpeechTrialConfiguration = (
     ),
     provider,
     targetWords: setup.targetWords,
-    languageCode: resolveRsvpSpeechLanguageCode(
+    languageCode: resolveRsvpSpeechProviderLanguageCode(
       provider,
-      setup.experimentLanguage,
+      setup.conditionLanguage,
     ),
     targetKeytermBiasEnabled: requireBoolean(
       setup.targetKeytermBiasEnabled,
@@ -252,6 +253,12 @@ export const prepareRsvpSpeechTrial = async (
   } catch (error) {
     if (runtime.controller === controller) runtime.controller = undefined;
     removePageHideListener();
+    if (controller) {
+      const failedController = controller;
+      await Promise.resolve()
+        .then(() => failedController.close())
+        .catch(() => undefined);
+    }
     runtime.status = "failed";
     runtime.error = error;
     return false;
@@ -378,14 +385,26 @@ export const getRsvpSpeechResult = (): SpeechUtteranceResult | undefined =>
   runtime.result;
 
 export const hasActiveRsvpSpeechResources = (): boolean =>
-  runtime.controller !== undefined;
+  runtime.controller !== undefined || activeClosePromise !== undefined;
 
 export const closeActiveRsvpSpeechTrial = async (): Promise<void> => {
+  if (activeClosePromise && runtime.controller === undefined) {
+    await activeClosePromise;
+    return;
+  }
+
   const controller = runtime.controller;
   runtime.controller = undefined;
   removePageHideListener();
   activeResultPromise = undefined;
-  if (controller) await controller.close().catch(() => undefined);
+  if (controller) {
+    const closePromise = Promise.resolve()
+      .then(() => controller.close())
+      .catch(() => undefined);
+    activeClosePromise = closePromise;
+    await closePromise;
+    if (activeClosePromise === closePromise) activeClosePromise = undefined;
+  }
   if (runtime.status !== "completed" && runtime.status !== "failed") {
     runtime.status = "closed";
   }

--- a/components/rsvpSpeech/rsvpSpeechScoring.ts
+++ b/components/rsvpSpeech/rsvpSpeechScoring.ts
@@ -1,0 +1,509 @@
+import {
+  normalizeSpeechToken,
+  tokenizeSpeechTranscript,
+  type NormalizedSpeechToken,
+  type SpeechLanguageProfileId,
+} from "../speech/textNormalization";
+import {
+  alignSpeechTokensToTargets,
+  characterSimilarity,
+  type SpeechTokenAlignmentEvent,
+} from "../speech/tokenAlignment";
+
+export const RSVP_SPEECH_SCORING_VERSION = "rsvp-position-aware-v1";
+
+export type RsvpSpeechScoringErrorCode =
+  | "emptyTranscript"
+  | "invalidTargets"
+  | "invalidPolicy";
+
+export class RsvpSpeechScoringError extends Error {
+  readonly code: RsvpSpeechScoringErrorCode;
+
+  constructor(code: RsvpSpeechScoringErrorCode, message: string) {
+    super(message);
+    this.name = "RsvpSpeechScoringError";
+    this.code = code;
+  }
+}
+
+export type RsvpSpeechWordOrderPolicy = "strict" | "anyOrder";
+export type RsvpSpeechRepetitionPolicy = "ignore" | "markIncorrect";
+export type RsvpSpeechSelfCorrectionPolicy = "accept" | "markIncorrect";
+
+export interface RsvpSpeechScoringPolicy {
+  readonly wordOrder: RsvpSpeechWordOrderPolicy;
+  readonly repetition: RsvpSpeechRepetitionPolicy;
+  readonly selfCorrection: RsvpSpeechSelfCorrectionPolicy;
+}
+
+export interface RsvpSpeechScoringInput {
+  readonly targetWords: readonly string[];
+  readonly transcript: string;
+  readonly languageCode: string;
+  readonly policy: RsvpSpeechScoringPolicy;
+}
+
+export type RsvpSpeechInsertionKind =
+  | "filler"
+  | "repetition"
+  | "selfCorrectionAttempt"
+  | "outOfOrderTarget";
+
+export interface RsvpSpeechScoringEvent extends SpeechTokenAlignmentEvent {
+  readonly insertionKind?: RsvpSpeechInsertionKind;
+  readonly relatedTargetIndex?: number;
+  readonly relatedTargetIndices?: readonly number[];
+  readonly similarityToTarget?: number;
+}
+
+export type RsvpSpeechTargetOutcome =
+  | "correct"
+  | "substitution"
+  | "outOfOrder"
+  | "omission"
+  | "rejectedByPolicy";
+
+export interface RsvpSpeechTargetResult {
+  readonly targetIndex: number;
+  readonly targetWord: string;
+  readonly responseText: string | null;
+  readonly correct: 0 | 1;
+  readonly outcome: RsvpSpeechTargetOutcome;
+}
+
+export interface RsvpSpeechScoringDiagnostics {
+  readonly scoringVersion: typeof RSVP_SPEECH_SCORING_VERSION;
+  readonly languageCode: string;
+  readonly languageProfile: SpeechLanguageProfileId;
+  readonly languageProfileVersion: string;
+  readonly normalizedTargetWords: readonly string[];
+  readonly normalizedTranscript: string;
+  readonly transcriptTokenCount: number;
+  readonly insertionCount: number;
+  readonly fillerCount: number;
+  readonly repetitionCount: number;
+  readonly selfCorrectionCount: number;
+  readonly outOfOrderCount: number;
+  readonly omissionCount: number;
+  readonly substitutionCount: number;
+  readonly splitTranscriptCount: number;
+  readonly mergedTargetGroupCount: number;
+  readonly phoneticCandidateCount: number;
+  readonly alignmentCost: number;
+  readonly events: readonly RsvpSpeechScoringEvent[];
+}
+
+export interface RsvpSpeechScoringResult {
+  readonly responseVector: readonly (0 | 1)[];
+  readonly targetResults: readonly RsvpSpeechTargetResult[];
+  readonly policy: Readonly<RsvpSpeechScoringPolicy>;
+  readonly diagnostics: RsvpSpeechScoringDiagnostics;
+}
+
+const validatePolicy = (policy: RsvpSpeechScoringPolicy): void => {
+  if (!policy || !["strict", "anyOrder"].includes(policy.wordOrder)) {
+    throw new RsvpSpeechScoringError(
+      "invalidPolicy",
+      "RSVP speech scoring requires a valid word-order policy.",
+    );
+  }
+  if (!["ignore", "markIncorrect"].includes(policy.repetition)) {
+    throw new RsvpSpeechScoringError(
+      "invalidPolicy",
+      "RSVP speech scoring requires a valid repetition policy.",
+    );
+  }
+  if (!["accept", "markIncorrect"].includes(policy.selfCorrection)) {
+    throw new RsvpSpeechScoringError(
+      "invalidPolicy",
+      "RSVP speech scoring requires a valid self-correction policy.",
+    );
+  }
+};
+
+const ensureValidTargets = (
+  targets: readonly NormalizedSpeechToken[],
+): void => {
+  targets.forEach((target) => {
+    if (!target.comparisonKey) {
+      throw new RsvpSpeechScoringError(
+        "invalidTargets",
+        "RSVP speech target words cannot normalize to empty text.",
+      );
+    }
+  });
+};
+
+const transcriptText = (
+  event: SpeechTokenAlignmentEvent,
+  transcript: readonly NormalizedSpeechToken[],
+): string | null => {
+  if (event.transcriptIndices.length === 0) return null;
+  return event.transcriptIndices
+    .map((index) => transcript[index]?.original ?? "")
+    .filter(Boolean)
+    .join(" ");
+};
+
+const targetEventMap = (
+  events: readonly SpeechTokenAlignmentEvent[],
+): ReadonlyMap<number, SpeechTokenAlignmentEvent> => {
+  const map = new Map<number, SpeechTokenAlignmentEvent>();
+  events.forEach((event) => {
+    event.targetIndices.forEach((targetIndex) => map.set(targetIndex, event));
+  });
+  return map;
+};
+
+const similarityThreshold = (left: string, right: string): number =>
+  Math.min([...left].length, [...right].length) <= 3 ? 2 / 3 : 0.6;
+
+const classifyInsertions = (
+  events: readonly SpeechTokenAlignmentEvent[],
+  targets: readonly NormalizedSpeechToken[],
+  transcript: readonly NormalizedSpeechToken[],
+): RsvpSpeechScoringEvent[] => {
+  const targetIndicesByKey = new Map<string, number[]>();
+  targets.forEach((target, index) => {
+    const indices = targetIndicesByKey.get(target.comparisonKey) ?? [];
+    indices.push(index);
+    targetIndicesByKey.set(target.comparisonKey, indices);
+  });
+  const eventIndexForMatchedTarget = new Map<number, number>();
+  events.forEach((event, eventIndex) => {
+    if (event.operation === "match") {
+      event.targetIndices.forEach((targetIndex) =>
+        eventIndexForMatchedTarget.set(targetIndex, eventIndex),
+      );
+    }
+  });
+
+  return events.map((event, eventIndex) => {
+    if (event.operation !== "insertion") return event;
+    const transcriptIndex = event.transcriptIndices[0];
+    const insertedToken = transcript[transcriptIndex];
+    const namedTargetIndices =
+      targetIndicesByKey.get(insertedToken.comparisonKey) ?? [];
+    if (namedTargetIndices.length > 0) {
+      const matchedBefore = namedTargetIndices
+        .map((targetIndex) => ({
+          targetIndex,
+          eventIndex: eventIndexForMatchedTarget.get(targetIndex),
+        }))
+        .filter(
+          (
+            candidate,
+          ): candidate is { targetIndex: number; eventIndex: number } =>
+            candidate.eventIndex !== undefined &&
+            candidate.eventIndex < eventIndex,
+        )
+        .sort((left, right) => right.eventIndex - left.eventIndex)[0];
+      const matchedAfter = namedTargetIndices
+        .map((targetIndex) => ({
+          targetIndex,
+          eventIndex: eventIndexForMatchedTarget.get(targetIndex),
+        }))
+        .filter(
+          (
+            candidate,
+          ): candidate is { targetIndex: number; eventIndex: number } =>
+            candidate.eventIndex !== undefined &&
+            candidate.eventIndex > eventIndex,
+        )
+        .sort((left, right) => left.eventIndex - right.eventIndex)[0];
+      const namedTargetIndex =
+        matchedBefore?.targetIndex ??
+        matchedAfter?.targetIndex ??
+        namedTargetIndices.reduce((closest, candidate) => {
+          const anchor = event.beforeTargetIndex ?? targets.length;
+          return Math.abs(candidate - anchor) < Math.abs(closest - anchor)
+            ? candidate
+            : closest;
+        });
+      return {
+        ...event,
+        insertionKind: matchedBefore ? "repetition" : "outOfOrderTarget",
+        relatedTargetIndex: namedTargetIndex,
+        relatedTargetIndices: [namedTargetIndex],
+      };
+    }
+
+    const matchingMergedEventIndex = events.findIndex(
+      (candidate) =>
+        candidate.matchKind === "mergedTargets" &&
+        candidate.transcriptIndices.some(
+          (candidateTranscriptIndex) =>
+            transcript[candidateTranscriptIndex]?.comparisonKey ===
+            insertedToken.comparisonKey,
+        ),
+    );
+    if (matchingMergedEventIndex >= 0) {
+      const matchingMergedEvent = events[matchingMergedEventIndex];
+      return {
+        ...event,
+        insertionKind:
+          matchingMergedEventIndex < eventIndex
+            ? "repetition"
+            : "outOfOrderTarget",
+        relatedTargetIndex: matchingMergedEvent.targetIndices[0],
+        relatedTargetIndices: matchingMergedEvent.targetIndices,
+      };
+    }
+
+    const nextEvent = events[eventIndex + 1];
+    if (
+      nextEvent?.operation === "match" &&
+      nextEvent.targetIndices.length === 1 &&
+      nextEvent.transcriptIndices[0] === transcriptIndex + 1
+    ) {
+      const relatedTargetIndex = nextEvent.targetIndices[0];
+      const target = targets[relatedTargetIndex];
+      const similarity = characterSimilarity(
+        insertedToken.comparisonKey,
+        target.comparisonKey,
+      );
+      if (
+        similarity >=
+        similarityThreshold(insertedToken.comparisonKey, target.comparisonKey)
+      ) {
+        return {
+          ...event,
+          insertionKind: "selfCorrectionAttempt",
+          relatedTargetIndex,
+          relatedTargetIndices: [relatedTargetIndex],
+          similarityToTarget: similarity,
+        };
+      }
+    }
+
+    return { ...event, insertionKind: "filler" };
+  });
+};
+
+const scoreWithoutOrder = (
+  targets: readonly NormalizedSpeechToken[],
+  transcript: readonly NormalizedSpeechToken[],
+  alignmentEvents: readonly SpeechTokenAlignmentEvent[],
+): {
+  vector: (0 | 1)[];
+  responseTextByTarget: Map<number, string>;
+} => {
+  const vector: (0 | 1)[] = Array(targets.length).fill(0);
+  const responseTextByTarget = new Map<number, string>();
+  const usedTranscriptIndices = new Set<number>();
+  targets.forEach((target, targetIndex) => {
+    const directIndex = transcript.findIndex(
+      (token, transcriptIndex) =>
+        !usedTranscriptIndices.has(transcriptIndex) &&
+        token.comparisonKey === target.comparisonKey,
+    );
+    if (directIndex < 0) return;
+    vector[targetIndex] = 1;
+    usedTranscriptIndices.add(directIndex);
+    responseTextByTarget.set(targetIndex, transcript[directIndex].original);
+  });
+  alignmentEvents.forEach((event) => {
+    if (
+      event.matchKind !== "mergedTargets" &&
+      event.matchKind !== "joinedTranscript"
+    ) {
+      return;
+    }
+    if (
+      event.targetIndices.some((targetIndex) => vector[targetIndex] === 1) ||
+      event.transcriptIndices.some((transcriptIndex) =>
+        usedTranscriptIndices.has(transcriptIndex),
+      )
+    ) {
+      return;
+    }
+    const responseText = transcriptText(event, transcript);
+    if (responseText === null) return;
+    event.transcriptIndices.forEach((transcriptIndex) =>
+      usedTranscriptIndices.add(transcriptIndex),
+    );
+    event.targetIndices.forEach((targetIndex) => {
+      vector[targetIndex] = 1;
+      responseTextByTarget.set(targetIndex, responseText);
+    });
+  });
+  return { vector, responseTextByTarget };
+};
+
+export const scoreRsvpSpeechResponse = (
+  input: RsvpSpeechScoringInput,
+): RsvpSpeechScoringResult => {
+  if (!Array.isArray(input.targetWords) || input.targetWords.length === 0) {
+    throw new RsvpSpeechScoringError(
+      "invalidTargets",
+      "RSVP speech scoring requires at least one target word.",
+    );
+  }
+  validatePolicy(input.policy);
+  const targets = input.targetWords.map((target) =>
+    normalizeSpeechToken(target, input.languageCode),
+  );
+  ensureValidTargets(targets);
+  const tokenization = tokenizeSpeechTranscript(
+    input.transcript,
+    input.languageCode,
+  );
+  const transcript = tokenization.tokens;
+  if (transcript.length === 0) {
+    throw new RsvpSpeechScoringError(
+      "emptyTranscript",
+      "RSVP speech scoring cannot score an empty transcript.",
+    );
+  }
+  const alignment = alignSpeechTokensToTargets(targets, transcript);
+  const events = classifyInsertions(alignment.events, targets, transcript);
+  const eventsByTarget = targetEventMap(events);
+
+  let responseTextByTarget = new Map<number, string>();
+  let vector: (0 | 1)[];
+  if (input.policy.wordOrder === "anyOrder") {
+    const unordered = scoreWithoutOrder(targets, transcript, events);
+    vector = unordered.vector;
+    responseTextByTarget = unordered.responseTextByTarget;
+  } else {
+    vector = targets.map((_, targetIndex): 0 | 1 => {
+      const event = eventsByTarget.get(targetIndex);
+      if (event?.operation !== "match") return 0;
+      const response = transcriptText(event, transcript);
+      if (response !== null) responseTextByTarget.set(targetIndex, response);
+      return 1;
+    });
+
+    events.forEach((event) => {
+      if (
+        event.insertionKind === "outOfOrderTarget" &&
+        event.beforeTargetIndex !== null &&
+        event.beforeTargetIndex < vector.length
+      ) {
+        vector[event.beforeTargetIndex] = 0;
+      }
+    });
+  }
+
+  if (input.policy.repetition === "markIncorrect") {
+    events.forEach((event) => {
+      if (event.insertionKind === "repetition") {
+        event.relatedTargetIndices?.forEach((targetIndex) => {
+          vector[targetIndex] = 0;
+        });
+      }
+    });
+  }
+  if (input.policy.selfCorrection === "markIncorrect") {
+    events.forEach((event) => {
+      if (
+        event.insertionKind === "selfCorrectionAttempt" &&
+        event.relatedTargetIndex !== undefined
+      ) {
+        vector[event.relatedTargetIndex] = 0;
+      }
+    });
+  }
+
+  const outOfOrderTargets = new Set<number>();
+  events.forEach((event) => {
+    if (event.matchKind === "outOfOrderTarget") {
+      event.targetIndices.forEach((targetIndex) =>
+        outOfOrderTargets.add(targetIndex),
+      );
+    }
+    if (
+      event.insertionKind === "outOfOrderTarget" &&
+      event.beforeTargetIndex !== null &&
+      event.beforeTargetIndex < targets.length
+    ) {
+      outOfOrderTargets.add(event.beforeTargetIndex);
+    }
+  });
+
+  const policyRejectedTargets = new Set<number>();
+  events.forEach((event) => {
+    const rejected =
+      (event.insertionKind === "repetition" &&
+        input.policy.repetition === "markIncorrect") ||
+      (event.insertionKind === "selfCorrectionAttempt" &&
+        input.policy.selfCorrection === "markIncorrect");
+    if (rejected) {
+      event.relatedTargetIndices?.forEach((targetIndex) =>
+        policyRejectedTargets.add(targetIndex),
+      );
+    }
+  });
+
+  const targetResults = targets.map((target, targetIndex) => {
+    const event = eventsByTarget.get(targetIndex);
+    const correct = vector[targetIndex];
+    let outcome: RsvpSpeechTargetOutcome;
+    if (policyRejectedTargets.has(targetIndex)) outcome = "rejectedByPolicy";
+    else if (correct) outcome = "correct";
+    else if (outOfOrderTargets.has(targetIndex)) outcome = "outOfOrder";
+    else if (event?.operation === "substitution") outcome = "substitution";
+    else outcome = "omission";
+    return {
+      targetIndex,
+      targetWord: input.targetWords[targetIndex],
+      responseText:
+        responseTextByTarget.get(targetIndex) ??
+        (event ? transcriptText(event, transcript) : null),
+      correct,
+      outcome,
+    };
+  });
+
+  const insertionEvents = events.filter(
+    (event) => event.operation === "insertion",
+  );
+  return {
+    responseVector: vector,
+    targetResults,
+    policy: { ...input.policy },
+    diagnostics: {
+      scoringVersion: RSVP_SPEECH_SCORING_VERSION,
+      languageCode: tokenization.languageCode,
+      languageProfile: tokenization.profileId,
+      languageProfileVersion: tokenization.profileVersion,
+      normalizedTargetWords: targets.map((target) => target.normalized),
+      normalizedTranscript: transcript
+        .map((token) => token.normalized)
+        .join(" "),
+      transcriptTokenCount: transcript.length,
+      insertionCount: insertionEvents.length,
+      fillerCount: insertionEvents.filter(
+        (event) => event.insertionKind === "filler",
+      ).length,
+      repetitionCount: insertionEvents.filter(
+        (event) => event.insertionKind === "repetition",
+      ).length,
+      selfCorrectionCount: insertionEvents.filter(
+        (event) => event.insertionKind === "selfCorrectionAttempt",
+      ).length,
+      outOfOrderCount: events.filter(
+        (event) =>
+          event.matchKind === "outOfOrderTarget" ||
+          event.insertionKind === "outOfOrderTarget",
+      ).length,
+      omissionCount: events.filter((event) => event.operation === "omission")
+        .length,
+      substitutionCount: events.filter(
+        (event) => event.operation === "substitution",
+      ).length,
+      splitTranscriptCount: events.filter(
+        (event) => event.matchKind === "joinedTranscript",
+      ).length,
+      mergedTargetGroupCount: events.filter(
+        (event) => event.matchKind === "mergedTargets",
+      ).length,
+      phoneticCandidateCount: events.filter(
+        (event) => event.matchKind === "phoneticCandidate",
+      ).length,
+      alignmentCost: alignment.totalCost,
+      events,
+    },
+  };
+};

--- a/components/rsvpSpeech/rsvpSpeechValidity.ts
+++ b/components/rsvpSpeech/rsvpSpeechValidity.ts
@@ -1,0 +1,53 @@
+import type { RsvpReadingResponseMode } from "./rsvpSpeechMode";
+import type { RsvpSpeechRuntimeStatus } from "./rsvpSpeechRuntime";
+
+export type RsvpSpeechInvalidReason =
+  | "preExposureTechnicalFailure"
+  | "postExposureTechnicalFailure"
+  | "responseNotRegistered";
+
+export interface RsvpSpeechTrialValidityInput {
+  readonly responseMode: RsvpReadingResponseMode;
+  readonly runtimeStatus: RsvpSpeechRuntimeStatus;
+  readonly captureStarted: boolean;
+  readonly registeredResponseCount: number;
+  readonly expectedResponseCount: number;
+}
+
+export interface RsvpSpeechTrialValidity {
+  readonly validForQuest: boolean;
+  readonly consumeTargetWords: boolean;
+  readonly invalidReason?: RsvpSpeechInvalidReason;
+}
+
+export const resolveRsvpSpeechTrialValidity = (
+  input: RsvpSpeechTrialValidityInput,
+): RsvpSpeechTrialValidity => {
+  if (input.responseMode !== "automaticSpeech") {
+    return { validForQuest: true, consumeTargetWords: true };
+  }
+
+  const responseWasRegistered =
+    input.runtimeStatus === "completed" &&
+    input.registeredResponseCount === input.expectedResponseCount;
+  if (responseWasRegistered) {
+    return { validForQuest: true, consumeTargetWords: true };
+  }
+
+  if (!input.captureStarted) {
+    return {
+      validForQuest: false,
+      consumeTargetWords: false,
+      invalidReason: "preExposureTechnicalFailure",
+    };
+  }
+
+  return {
+    validForQuest: false,
+    consumeTargetWords: true,
+    invalidReason:
+      input.runtimeStatus === "completed"
+        ? "responseNotRegistered"
+        : "postExposureTechnicalFailure",
+  };
+};

--- a/components/speech/textNormalization.ts
+++ b/components/speech/textNormalization.ts
@@ -1,0 +1,355 @@
+export type SpeechLanguageProfileId = "default" | "en" | "fa" | "ar";
+
+export interface NormalizedSpeechToken {
+  readonly original: string;
+  readonly normalized: string;
+  readonly comparisonKey: string;
+  readonly languageCode: string;
+  readonly profileId: SpeechLanguageProfileId;
+  readonly profileVersion: string;
+  readonly phoneticKeys: readonly string[];
+}
+
+export type SpeechTokenSplitMatchKind =
+  | "explicitJoinControl"
+  | "persianAffixBoundary";
+
+export interface SpeechTranscriptTokenization {
+  readonly rawText: string;
+  readonly languageCode: string;
+  readonly profileId: SpeechLanguageProfileId;
+  readonly profileVersion: string;
+  readonly tokens: readonly NormalizedSpeechToken[];
+}
+
+interface SpeechLanguageProfile {
+  readonly id: SpeechLanguageProfileId;
+  readonly version: string;
+  prepareText(text: string): string;
+  normalizeToken(token: string, languageCode: string): NormalizedSpeechToken;
+}
+
+const ZWNJ = "\u200C";
+const NON_STANDARD_JOIN_CONTROLS = /[\u200B\u200D\u2060\uFEFF]/g;
+const ALL_JOIN_CONTROLS = /[\u200B-\u200D\u2060\uFEFF]/g;
+const JOIN_CONTROL_CHARACTER = /[\u200B-\u200D\u2060\uFEFF]/u;
+const APOSTROPHE_VARIANTS = /[\u2018\u2019\u02BC\u0060\u00B4]/g;
+const DASH_VARIANTS = /[\u2010-\u2015\u2212]/g;
+const EDGE_NON_WORD =
+  /^[^\p{L}\p{N}\p{M}\u200C\u200D]+|[^\p{L}\p{N}\p{M}\u200C\u200D]+$/gu;
+const CONTAINS_LETTER_OR_NUMBER = /[\p{L}\p{N}]/u;
+const NUMBER = /\p{N}/u;
+const PUNCTUATION_RUN_BETWEEN_WORD_CHARACTERS =
+  /([\p{L}\p{N}\p{M}])(\p{P}+)(?=([\p{L}\p{N}\p{M}]))/gu;
+
+const LEXICAL_INTERNAL_PUNCTUATION = new Set([
+  "'",
+  "\u2018",
+  "\u2019",
+  "\u02BC",
+  "\u0060",
+  "\u00B4",
+  "-",
+  "\u2010",
+  "\u2011",
+]);
+
+const NUMERIC_INTERNAL_PUNCTUATION = new Set([
+  ".",
+  ",",
+  ":",
+  "/",
+  "\u066B",
+  "\u066C",
+  "\uFF0E",
+  "\uFF0C",
+  "\uFF1A",
+  "\uFF0F",
+]);
+
+const ARABIC_YEH = /\u064A/g;
+const PERSIAN_YEH = "\u06CC";
+const PERSIAN_YEH_PATTERN = /\u06CC/g;
+const ARABIC_KAF = /\u0643/g;
+const PERSIAN_KAF = "\u06A9";
+const PERSIAN_KAF_PATTERN = /\u06A9/g;
+const TATWEEL = /\u0640/g;
+const ARABIC_DIACRITICS = /[\u0610-\u061A\u064B-\u065F\u0670\u06D6-\u06ED]/g;
+
+const PERSIAN_PHONETIC_EQUIVALENTS: Readonly<Record<string, string>> =
+  Object.freeze({
+    "\u0633": "S",
+    "\u0635": "S",
+    "\u062B": "S",
+    "\u0632": "Z",
+    "\u0630": "Z",
+    "\u0636": "Z",
+    "\u0638": "Z",
+    "\u062A": "T",
+    "\u0637": "T",
+    "\u0642": "Q",
+    "\u063A": "Q",
+    "\u0647": "H",
+    "\u062D": "H",
+    "\u0627": "A",
+    "\u0622": "A",
+    "\u0623": "A",
+    "\u0625": "A",
+    "\u06A9": "K",
+    "\u0643": "K",
+    "\u06CC": "Y",
+    "\u064A": "Y",
+    "\u0648": "V",
+    "\u0639": "E",
+  });
+
+const PERSIAN_SEPARABLE_PREFIXES = new Set([
+  "\u0645\u06CC",
+  "\u0646\u0645\u06CC",
+]);
+const PERSIAN_SEPARABLE_SUFFIXES = new Set([
+  "\u0647\u0627",
+  "\u0647\u0627\u06CC",
+  "\u0647\u0627\u06CC\u06CC",
+  "\u062A\u0631",
+  "\u062A\u0631\u06CC\u0646",
+]);
+
+const normalizeLanguageCode = (languageCode: string): string => {
+  const normalized = String(languageCode ?? "")
+    .trim()
+    .replace(/_/g, "-");
+  if (!normalized) throw new Error("A speech language code is required.");
+  return normalized;
+};
+
+const baseLanguage = (languageCode: string): string =>
+  normalizeLanguageCode(languageCode).split("-")[0].toLowerCase();
+
+const localeLowerCase = (text: string, languageCode: string): string => {
+  try {
+    return text.toLocaleLowerCase(languageCode);
+  } catch {
+    return text.toLowerCase();
+  }
+};
+
+const prepareJoinControls = (text: string): string =>
+  text
+    .normalize("NFC")
+    .replace(NON_STANDARD_JOIN_CONTROLS, ZWNJ)
+    .replace(/[\t ]*\u200C+[\t ]*/g, ZWNJ);
+
+const preparePunctuationBoundaries = (text: string): string =>
+  text.replace(
+    PUNCTUATION_RUN_BETWEEN_WORD_CHARACTERS,
+    (match, left: string, punctuation: string, right: string) => {
+      const characters = [...punctuation];
+      if (
+        characters.length === 1 &&
+        LEXICAL_INTERNAL_PUNCTUATION.has(characters[0])
+      ) {
+        return match;
+      }
+      const numericExpression =
+        NUMBER.test(left) &&
+        NUMBER.test(right) &&
+        characters.every((character) =>
+          NUMERIC_INTERNAL_PUNCTUATION.has(character),
+        );
+      return numericExpression ? match : `${left} `;
+    },
+  );
+
+const tokenResult = (
+  original: string,
+  normalized: string,
+  comparisonKey: string,
+  languageCode: string,
+  profile: Pick<SpeechLanguageProfile, "id" | "version">,
+  phoneticKeys: readonly string[] = [],
+): NormalizedSpeechToken => ({
+  original,
+  normalized,
+  comparisonKey,
+  languageCode,
+  profileId: profile.id,
+  profileVersion: profile.version,
+  phoneticKeys,
+});
+
+const persianPhoneticKey = (normalized: string): string =>
+  [...normalized]
+    .filter((character) => !JOIN_CONTROL_CHARACTER.test(character))
+    .map((character) => PERSIAN_PHONETIC_EQUIVALENTS[character] ?? character)
+    .join("");
+
+const defaultProfile: SpeechLanguageProfile = {
+  id: "default",
+  version: "unicode-nfc-v1",
+  prepareText: (text) => text.normalize("NFC"),
+  normalizeToken: (token, languageCode) => {
+    const normalized = localeLowerCase(
+      token.normalize("NFC").replace(EDGE_NON_WORD, ""),
+      languageCode,
+    );
+    return tokenResult(
+      token,
+      normalized,
+      normalized.replace(ALL_JOIN_CONTROLS, ""),
+      languageCode,
+      defaultProfile,
+    );
+  },
+};
+
+const englishProfile: SpeechLanguageProfile = {
+  id: "en",
+  version: "english-nfkc-v1",
+  prepareText: (text) => text.normalize("NFKC"),
+  normalizeToken: (token, languageCode) => {
+    const normalized = token
+      .normalize("NFKC")
+      .replace(APOSTROPHE_VARIANTS, "'")
+      .replace(DASH_VARIANTS, "-")
+      .toLocaleLowerCase("en-US")
+      .replace(EDGE_NON_WORD, "");
+    return tokenResult(
+      token,
+      normalized,
+      normalized,
+      languageCode,
+      englishProfile,
+    );
+  },
+};
+
+const persianProfile: SpeechLanguageProfile = {
+  id: "fa",
+  version: "persian-orthographic-v1",
+  prepareText: prepareJoinControls,
+  normalizeToken: (token, languageCode) => {
+    const normalized = prepareJoinControls(token)
+      .replace(ARABIC_YEH, PERSIAN_YEH)
+      .replace(ARABIC_KAF, PERSIAN_KAF)
+      .replace(TATWEEL, "")
+      .replace(ARABIC_DIACRITICS, "")
+      .replace(EDGE_NON_WORD, "");
+    return tokenResult(
+      token,
+      normalized,
+      normalized.replace(ALL_JOIN_CONTROLS, ""),
+      languageCode,
+      persianProfile,
+      normalized ? [persianPhoneticKey(normalized)] : [],
+    );
+  },
+};
+
+const arabicProfile: SpeechLanguageProfile = {
+  id: "ar",
+  version: "arabic-orthographic-v1",
+  prepareText: prepareJoinControls,
+  normalizeToken: (token, languageCode) => {
+    const normalized = prepareJoinControls(token)
+      .replace(PERSIAN_YEH_PATTERN, "\u064A")
+      .replace(PERSIAN_KAF_PATTERN, "\u0643")
+      .replace(TATWEEL, "")
+      .replace(ARABIC_DIACRITICS, "")
+      .replace(EDGE_NON_WORD, "");
+    return tokenResult(
+      token,
+      normalized,
+      normalized.replace(ALL_JOIN_CONTROLS, ""),
+      languageCode,
+      arabicProfile,
+    );
+  },
+};
+
+const resolveProfile = (languageCode: string): SpeechLanguageProfile => {
+  switch (baseLanguage(languageCode)) {
+    case "en":
+      return englishProfile;
+    case "fa":
+    case "fas":
+      return persianProfile;
+    case "ar":
+    case "ara":
+      return arabicProfile;
+    default:
+      return defaultProfile;
+  }
+};
+
+export const normalizeSpeechToken = (
+  token: string,
+  languageCode: string,
+): NormalizedSpeechToken => {
+  const normalizedLanguageCode = normalizeLanguageCode(languageCode);
+  return resolveProfile(normalizedLanguageCode).normalizeToken(
+    String(token ?? ""),
+    normalizedLanguageCode,
+  );
+};
+
+export const tokenizeSpeechTranscript = (
+  text: string,
+  languageCode: string,
+): SpeechTranscriptTokenization => {
+  const normalizedLanguageCode = normalizeLanguageCode(languageCode);
+  const profile = resolveProfile(normalizedLanguageCode);
+  const rawText = String(text ?? "");
+  const preparedText = preparePunctuationBoundaries(
+    profile.prepareText(rawText),
+  );
+  const tokens = preparedText
+    .split(/\s+/u)
+    .filter(Boolean)
+    .map((token) => profile.normalizeToken(token, normalizedLanguageCode))
+    .filter(
+      (token) =>
+        token.comparisonKey.length > 0 &&
+        CONTAINS_LETTER_OR_NUMBER.test(token.comparisonKey),
+    );
+
+  return {
+    rawText,
+    languageCode: normalizedLanguageCode,
+    profileId: profile.id,
+    profileVersion: profile.version,
+    tokens,
+  };
+};
+
+export const speechTokenSplitMatchKind = (
+  target: NormalizedSpeechToken,
+  transcriptParts: readonly NormalizedSpeechToken[],
+): SpeechTokenSplitMatchKind | null => {
+  if (
+    transcriptParts.length < 2 ||
+    transcriptParts.some((part) => part.profileId !== target.profileId) ||
+    transcriptParts.map((part) => part.comparisonKey).join("") !==
+      target.comparisonKey
+  ) {
+    return null;
+  }
+
+  if (
+    (target.profileId === "fa" || target.profileId === "ar") &&
+    target.normalized.includes(ZWNJ)
+  ) {
+    return "explicitJoinControl";
+  }
+
+  if (target.profileId !== "fa") return null;
+  const firstPart = transcriptParts[0].comparisonKey;
+  const lastPart = transcriptParts[transcriptParts.length - 1].comparisonKey;
+  if (
+    PERSIAN_SEPARABLE_PREFIXES.has(firstPart) ||
+    PERSIAN_SEPARABLE_SUFFIXES.has(lastPart)
+  ) {
+    return "persianAffixBoundary";
+  }
+  return null;
+};

--- a/components/speech/tokenAlignment.ts
+++ b/components/speech/tokenAlignment.ts
@@ -1,0 +1,442 @@
+import {
+  speechTokenSplitMatchKind,
+  type NormalizedSpeechToken,
+  type SpeechTokenSplitMatchKind,
+} from "./textNormalization";
+
+export type SpeechTokenAlignmentOperation =
+  | "match"
+  | "substitution"
+  | "omission"
+  | "insertion";
+
+export type SpeechTokenAlignmentMatchKind =
+  | "exact"
+  | "joinedTranscript"
+  | "mergedTargets"
+  | "phoneticCandidate"
+  | "outOfOrderTarget"
+  | "unrelated"
+  | null;
+
+export interface SpeechTokenAlignmentEvent {
+  readonly operation: SpeechTokenAlignmentOperation;
+  readonly matchKind: SpeechTokenAlignmentMatchKind;
+  readonly targetIndex: number | null;
+  readonly targetIndices: readonly number[];
+  readonly transcriptIndices: readonly number[];
+  readonly beforeTargetIndex: number | null;
+  readonly boundaryMatchKind?: SpeechTokenSplitMatchKind;
+  readonly cost: number;
+}
+
+export interface SpeechTokenAlignmentResult {
+  readonly events: readonly SpeechTokenAlignmentEvent[];
+  readonly totalCost: number;
+}
+
+type BacktrackOperation =
+  | "diagonal"
+  | "omission"
+  | "insertion"
+  | "joinedTranscript"
+  | "mergedTargets";
+
+interface BacktrackDecision {
+  readonly operation: BacktrackOperation;
+  readonly matchKind: SpeechTokenAlignmentMatchKind;
+  readonly transcriptTokenCount: number;
+  readonly targetTokenCount?: number;
+  readonly boundaryMatchKind?: SpeechTokenSplitMatchKind;
+  readonly stepCost: number;
+}
+
+const OMISSION_COST = 1;
+const INSERTION_COST = 1;
+const OUT_OF_ORDER_TARGET_COST = 0.4;
+const PHONETIC_CANDIDATE_COST = 0.8;
+const UNRELATED_SUBSTITUTION_COST = 2.1;
+const JOINED_TRANSCRIPT_COST = 0.05;
+const MERGED_TARGETS_COST = 0.05;
+const MAX_JOINED_TRANSCRIPT_TOKENS = 3;
+const MAX_MERGED_TARGET_TOKENS = 3;
+
+const targetIndexLookup = (
+  targets: readonly NormalizedSpeechToken[],
+): ReadonlyMap<string, readonly number[]> => {
+  const mutable = new Map<string, number[]>();
+  targets.forEach((target, index) => {
+    const indexes = mutable.get(target.comparisonKey) ?? [];
+    indexes.push(index);
+    mutable.set(target.comparisonKey, indexes);
+  });
+  return mutable;
+};
+
+const substitution = (
+  target: NormalizedSpeechToken,
+  transcript: NormalizedSpeechToken,
+  targetIndex: number,
+  targetIndexesByKey: ReadonlyMap<string, readonly number[]>,
+): Pick<BacktrackDecision, "matchKind" | "stepCost"> => {
+  if (target.comparisonKey === transcript.comparisonKey) {
+    return { matchKind: "exact", stepCost: 0 };
+  }
+  const matchingTargetIndexes =
+    targetIndexesByKey.get(transcript.comparisonKey) ?? [];
+  if (matchingTargetIndexes.some((index) => index !== targetIndex)) {
+    return {
+      matchKind: "outOfOrderTarget",
+      stepCost: OUT_OF_ORDER_TARGET_COST,
+    };
+  }
+  const transcriptPhoneticKeys = new Set(transcript.phoneticKeys);
+  if (target.phoneticKeys.some((key) => transcriptPhoneticKeys.has(key))) {
+    return {
+      matchKind: "phoneticCandidate",
+      stepCost: PHONETIC_CANDIDATE_COST,
+    };
+  }
+  return {
+    matchKind: "unrelated",
+    stepCost: UNRELATED_SUBSTITUTION_COST,
+  };
+};
+
+const joinedTranscriptMatchesTarget = (
+  target: NormalizedSpeechToken,
+  transcriptParts: readonly NormalizedSpeechToken[],
+): SpeechTokenSplitMatchKind | null =>
+  speechTokenSplitMatchKind(target, transcriptParts);
+
+const mergedTargetsMatchTranscript = (
+  targetParts: readonly NormalizedSpeechToken[],
+  transcript: NormalizedSpeechToken,
+  targetIndexesByKey: ReadonlyMap<string, readonly number[]>,
+  mergedTargetKeyCounts: ReadonlyMap<string, number>,
+): boolean =>
+  targetParts.length >= 2 &&
+  transcript.profileId === "fa" &&
+  targetParts.every((target) => target.profileId === "fa") &&
+  targetParts.map((target) => target.comparisonKey).join("") ===
+    transcript.comparisonKey &&
+  !targetIndexesByKey.has(transcript.comparisonKey) &&
+  mergedTargetKeyCounts.get(transcript.comparisonKey) === 1;
+
+const mergedTargetKeyCountLookup = (
+  targets: readonly NormalizedSpeechToken[],
+): ReadonlyMap<string, number> => {
+  const counts = new Map<string, number>();
+  for (let start = 0; start < targets.length; start += 1) {
+    for (
+      let count = 2;
+      count <= MAX_MERGED_TARGET_TOKENS && start + count <= targets.length;
+      count += 1
+    ) {
+      const parts = targets.slice(start, start + count);
+      if (parts.some((target) => target.profileId !== "fa")) continue;
+      const key = parts.map((target) => target.comparisonKey).join("");
+      counts.set(key, (counts.get(key) ?? 0) + 1);
+    }
+  }
+  return counts;
+};
+
+/**
+ * Produces a deterministic monotonic alignment. Exact matches are free,
+ * tokens naming another target position become substitutions, and unrelated
+ * speech remains an insertion instead of being forced onto a target.
+ */
+export const alignSpeechTokensToTargets = (
+  targets: readonly NormalizedSpeechToken[],
+  transcript: readonly NormalizedSpeechToken[],
+): SpeechTokenAlignmentResult => {
+  const targetCount = targets.length;
+  const transcriptCount = transcript.length;
+  const targetIndexesByKey = targetIndexLookup(targets);
+  const mergedTargetKeyCounts = mergedTargetKeyCountLookup(targets);
+  const costs = Array.from({ length: targetCount + 1 }, () =>
+    Array<number>(transcriptCount + 1).fill(Number.POSITIVE_INFINITY),
+  );
+  const backtrack = Array.from({ length: targetCount + 1 }, () =>
+    Array<BacktrackDecision | undefined>(transcriptCount + 1).fill(undefined),
+  );
+
+  costs[0][0] = 0;
+  for (let targetIndex = 1; targetIndex <= targetCount; targetIndex += 1) {
+    costs[targetIndex][0] = targetIndex * OMISSION_COST;
+    backtrack[targetIndex][0] = {
+      operation: "omission",
+      matchKind: null,
+      transcriptTokenCount: 0,
+      stepCost: OMISSION_COST,
+    };
+  }
+  for (
+    let transcriptIndex = 1;
+    transcriptIndex <= transcriptCount;
+    transcriptIndex += 1
+  ) {
+    costs[0][transcriptIndex] = transcriptIndex * INSERTION_COST;
+    backtrack[0][transcriptIndex] = {
+      operation: "insertion",
+      matchKind: null,
+      transcriptTokenCount: 1,
+      stepCost: INSERTION_COST,
+    };
+  }
+
+  for (let targetIndex = 1; targetIndex <= targetCount; targetIndex += 1) {
+    for (
+      let transcriptIndex = 1;
+      transcriptIndex <= transcriptCount;
+      transcriptIndex += 1
+    ) {
+      const diagonal = substitution(
+        targets[targetIndex - 1],
+        transcript[transcriptIndex - 1],
+        targetIndex - 1,
+        targetIndexesByKey,
+      );
+      const diagonalCost =
+        costs[targetIndex - 1][transcriptIndex - 1] + diagonal.stepCost;
+      const omissionCost =
+        costs[targetIndex - 1][transcriptIndex] + OMISSION_COST;
+      const insertionCost =
+        costs[targetIndex][transcriptIndex - 1] + INSERTION_COST;
+
+      let bestCost = diagonalCost;
+      let bestDecision: BacktrackDecision = {
+        operation: "diagonal",
+        matchKind: diagonal.matchKind,
+        transcriptTokenCount: 1,
+        stepCost: diagonal.stepCost,
+      };
+
+      if (omissionCost < bestCost) {
+        bestCost = omissionCost;
+        bestDecision = {
+          operation: "omission",
+          matchKind: null,
+          transcriptTokenCount: 0,
+          stepCost: OMISSION_COST,
+        };
+      }
+
+      const exactTrailingDuplicate =
+        diagonal.matchKind === "exact" &&
+        insertionCost === diagonalCost &&
+        omissionCost > diagonalCost;
+      if (insertionCost < bestCost || exactTrailingDuplicate) {
+        bestCost = insertionCost;
+        bestDecision = {
+          operation: "insertion",
+          matchKind: null,
+          transcriptTokenCount: 1,
+          stepCost: INSERTION_COST,
+        };
+      }
+
+      for (
+        let partCount = 2;
+        partCount <= MAX_JOINED_TRANSCRIPT_TOKENS &&
+        partCount <= transcriptIndex;
+        partCount += 1
+      ) {
+        const transcriptParts = transcript.slice(
+          transcriptIndex - partCount,
+          transcriptIndex,
+        );
+        const boundaryMatchKind = joinedTranscriptMatchesTarget(
+          targets[targetIndex - 1],
+          transcriptParts,
+        );
+        if (!boundaryMatchKind) continue;
+        const joinedCost =
+          costs[targetIndex - 1][transcriptIndex - partCount] +
+          JOINED_TRANSCRIPT_COST;
+        if (joinedCost < bestCost) {
+          bestCost = joinedCost;
+          bestDecision = {
+            operation: "joinedTranscript",
+            matchKind: "joinedTranscript",
+            transcriptTokenCount: partCount,
+            boundaryMatchKind,
+            stepCost: JOINED_TRANSCRIPT_COST,
+          };
+        }
+      }
+
+      for (
+        let partCount = 2;
+        partCount <= MAX_MERGED_TARGET_TOKENS && partCount <= targetIndex;
+        partCount += 1
+      ) {
+        const targetParts = targets.slice(targetIndex - partCount, targetIndex);
+        if (
+          !mergedTargetsMatchTranscript(
+            targetParts,
+            transcript[transcriptIndex - 1],
+            targetIndexesByKey,
+            mergedTargetKeyCounts,
+          )
+        ) {
+          continue;
+        }
+        const mergedCost =
+          costs[targetIndex - partCount][transcriptIndex - 1] +
+          MERGED_TARGETS_COST;
+        if (mergedCost < bestCost) {
+          bestCost = mergedCost;
+          bestDecision = {
+            operation: "mergedTargets",
+            matchKind: "mergedTargets",
+            transcriptTokenCount: 1,
+            targetTokenCount: partCount,
+            stepCost: MERGED_TARGETS_COST,
+          };
+        }
+      }
+
+      costs[targetIndex][transcriptIndex] = bestCost;
+      backtrack[targetIndex][transcriptIndex] = bestDecision;
+    }
+  }
+
+  const events: SpeechTokenAlignmentEvent[] = [];
+  let targetIndex = targetCount;
+  let transcriptIndex = transcriptCount;
+  while (targetIndex > 0 || transcriptIndex > 0) {
+    const decision = backtrack[targetIndex][transcriptIndex];
+    if (!decision) throw new Error("Speech token alignment is incomplete.");
+
+    switch (decision.operation) {
+      case "diagonal": {
+        const resolvedTargetIndex = targetIndex - 1;
+        const resolvedTranscriptIndex = transcriptIndex - 1;
+        events.unshift({
+          operation: decision.matchKind === "exact" ? "match" : "substitution",
+          matchKind: decision.matchKind,
+          targetIndex: resolvedTargetIndex,
+          targetIndices: [resolvedTargetIndex],
+          transcriptIndices: [resolvedTranscriptIndex],
+          beforeTargetIndex: null,
+          cost: decision.stepCost,
+        });
+        targetIndex -= 1;
+        transcriptIndex -= 1;
+        break;
+      }
+      case "joinedTranscript": {
+        const resolvedTargetIndex = targetIndex - 1;
+        const firstTranscriptIndex =
+          transcriptIndex - decision.transcriptTokenCount;
+        events.unshift({
+          operation: "match",
+          matchKind: "joinedTranscript",
+          targetIndex: resolvedTargetIndex,
+          targetIndices: [resolvedTargetIndex],
+          transcriptIndices: Array.from(
+            { length: decision.transcriptTokenCount },
+            (_, index) => firstTranscriptIndex + index,
+          ),
+          beforeTargetIndex: null,
+          boundaryMatchKind: decision.boundaryMatchKind,
+          cost: decision.stepCost,
+        });
+        targetIndex -= 1;
+        transcriptIndex -= decision.transcriptTokenCount;
+        break;
+      }
+      case "mergedTargets": {
+        const targetTokenCount = decision.targetTokenCount ?? 0;
+        if (targetTokenCount < 2) {
+          throw new Error("Merged speech targets are incomplete.");
+        }
+        const firstTargetIndex = targetIndex - targetTokenCount;
+        const resolvedTargetIndices = Array.from(
+          { length: targetTokenCount },
+          (_, index) => firstTargetIndex + index,
+        );
+        events.unshift({
+          operation: "match",
+          matchKind: "mergedTargets",
+          targetIndex: firstTargetIndex,
+          targetIndices: resolvedTargetIndices,
+          transcriptIndices: [transcriptIndex - 1],
+          beforeTargetIndex: null,
+          cost: decision.stepCost,
+        });
+        targetIndex -= targetTokenCount;
+        transcriptIndex -= 1;
+        break;
+      }
+      case "omission":
+        events.unshift({
+          operation: "omission",
+          matchKind: null,
+          targetIndex: targetIndex - 1,
+          targetIndices: [targetIndex - 1],
+          transcriptIndices: [],
+          beforeTargetIndex: null,
+          cost: decision.stepCost,
+        });
+        targetIndex -= 1;
+        break;
+      case "insertion":
+        events.unshift({
+          operation: "insertion",
+          matchKind: null,
+          targetIndex: null,
+          targetIndices: [],
+          transcriptIndices: [transcriptIndex - 1],
+          beforeTargetIndex: targetIndex,
+          cost: decision.stepCost,
+        });
+        transcriptIndex -= 1;
+        break;
+    }
+  }
+
+  return {
+    events,
+    totalCost: costs[targetCount][transcriptCount],
+  };
+};
+
+export const characterSimilarity = (left: string, right: string): number => {
+  const leftCharacters = [...left];
+  const rightCharacters = [...right];
+  if (leftCharacters.join("") === rightCharacters.join("")) return 1;
+  if (leftCharacters.length === 0 || rightCharacters.length === 0) return 0;
+
+  let previous = Array.from(
+    { length: rightCharacters.length + 1 },
+    (_, index) => index,
+  );
+  let current = Array<number>(rightCharacters.length + 1).fill(0);
+  for (let leftIndex = 1; leftIndex <= leftCharacters.length; leftIndex += 1) {
+    current[0] = leftIndex;
+    for (
+      let rightIndex = 1;
+      rightIndex <= rightCharacters.length;
+      rightIndex += 1
+    ) {
+      current[rightIndex] =
+        leftCharacters[leftIndex - 1] === rightCharacters[rightIndex - 1]
+          ? previous[rightIndex - 1]
+          : 1 +
+            Math.min(
+              previous[rightIndex - 1],
+              previous[rightIndex],
+              current[rightIndex - 1],
+            );
+    }
+    [previous, current] = [current, previous];
+  }
+  return (
+    1 -
+    previous[rightCharacters.length] /
+      Math.max(leftCharacters.length, rightCharacters.length)
+  );
+};

--- a/components/trialRoutines.js
+++ b/components/trialRoutines.js
@@ -24,7 +24,10 @@ import {
   responseType,
   showTimingBarsBool,
   phraseIdentificationResponse,
+  rsvpReadingResponse,
+  rsvpReadingTargetSets,
   rsvpReadingWordsForThisBlock,
+  rsvpSpeechRuntime,
   skipTrialOrBlock,
 } from "./global.js";
 import {
@@ -61,6 +64,7 @@ import { MultiStairHandler } from "../psychojs/src/data/MultiStairHandler.js";
 import { logQuest } from "./logging.js";
 import { removeHandlerForClickingFixation } from "./instructions.js";
 import { Screens } from "./multiple-displays/globals.ts";
+import { resolveRsvpSpeechTrialValidity } from "./rsvpSpeech/rsvpSpeechValidity.ts";
 
 export const _identify_trialInstructionRoutineEnd = (
   instructions,
@@ -322,7 +326,15 @@ export const _rsvpReading_trialRoutineEnd = (
 
     // Determine whether to retry trial based on goodness for QUEST,
     // preserving true if already set, ie because a trial was considered practice
-    const validTrialToGiveToQUEST = true; // TODO rsvp tolerance checks?;
+    const speechTrialValidity = resolveRsvpSpeechTrialValidity({
+      responseMode: rsvpReadingResponse.responseType,
+      runtimeStatus: rsvpSpeechRuntime.status,
+      captureStarted: rsvpSpeechRuntime.captureStartedAtMs !== undefined,
+      registeredResponseCount: phraseIdentificationResponse.correct.length,
+      expectedResponseCount:
+        rsvpReadingTargetSets.numberOfIdentifications ?? responses.length,
+    });
+    const validTrialToGiveToQUEST = speechTrialValidity.validForQuest;
     const okToRetryThisTrial = okayToRetryThisTrial(
       status,
       paramReader,
@@ -332,8 +344,10 @@ export const _rsvpReading_trialRoutineEnd = (
       status.retryThisTrialBool ||
       (!validTrialToGiveToQUEST && okToRetryThisTrial);
 
-    rsvpReadingWordsForThisBlock.current[status.block_condition].shift();
-    if (status.retryThisTrialBool) {
+    if (speechTrialValidity.consumeTargetWords) {
+      rsvpReadingWordsForThisBlock.current[status.block_condition].shift();
+    }
+    if (status.retryThisTrialBool && speechTrialValidity.consumeTargetWords) {
       const newWords = generateSupplementalRsvpReadingWords(
         paramReader,
         status.block_condition,

--- a/tests/lifetime.test.ts
+++ b/tests/lifetime.test.ts
@@ -59,6 +59,7 @@ jest.mock("../components/global", () => ({
   microphoneCalibrationResults: [],
   cursorTracking: { records: [] },
   status: { consentGiven: false },
+  rsvpSpeechRuntime: { controller: undefined },
 }));
 
 jest.mock("../components/recruitmentService", () => ({

--- a/tests/rsvpSpeechRuntime.test.ts
+++ b/tests/rsvpSpeechRuntime.test.ts
@@ -20,12 +20,13 @@ import {
   allowRsvpSpeechProviderFinalization,
   buildRsvpSpeechTrialConfiguration,
   clearRsvpSpeechRuntimeState,
+  closeActiveRsvpSpeechTrial,
   getRsvpSpeechResult,
   hasActiveRsvpSpeechResources,
   injectRsvpSpeechTranscriptForSimulation,
   prepareRsvpSpeechTrial,
   prepareSimulatedRsvpSpeechTrial,
-  resolveRsvpSpeechLanguageCode,
+  resolveRsvpSpeechProviderLanguageCode,
   startRsvpSpeechCapture,
   type RsvpSpeechTrialSetup,
 } from "../components/rsvpSpeech/rsvpSpeechRuntime";
@@ -36,7 +37,7 @@ const baseSetup = (): RsvpSpeechTrialSetup => ({
   trialNumber: 7,
   provider: "ElevenLabs",
   targetWords: ["cat", "dog", "fish"],
-  experimentLanguage: "en-US",
+  conditionLanguage: "en-US",
   targetKeytermBiasEnabled: true,
   maximumResponseDurationSec: 6,
   stimulusDurationMs: 750,
@@ -75,9 +76,13 @@ afterAll(async () => {
 });
 
 describe("RSVP speech trial configuration", () => {
-  it("maps the experiment locale to the provider-specific language format", () => {
-    expect(resolveRsvpSpeechLanguageCode("elevenlabs", "pt-BR")).toBe("pt");
-    expect(resolveRsvpSpeechLanguageCode("deepgram", "pt_BR")).toBe("pt-BR");
+  it("maps the condition locale to the provider-specific language format", () => {
+    expect(resolveRsvpSpeechProviderLanguageCode("elevenlabs", "pt-BR")).toBe(
+      "pt",
+    );
+    expect(resolveRsvpSpeechProviderLanguageCode("deepgram", "pt_BR")).toBe(
+      "pt-BR",
+    );
   });
 
   it("uses only the current trial targets and converts seconds to milliseconds", () => {
@@ -182,6 +187,41 @@ describe("RSVP speech runtime lifecycle", () => {
     expect(hasActiveRsvpSpeechResources()).toBe(false);
     expect(rsvpSpeechRuntime.status).toBe("failed");
     expect(rsvpSpeechRuntime.error).toBeInstanceOf(Error);
+    expect(controller.close).toHaveBeenCalledTimes(1);
+  });
+
+  it("waits for skipped-trial cleanup before preparing another controller", async () => {
+    const firstClose = deferred<void>();
+    const firstController = {
+      prepare: jest.fn(async () => undefined),
+      close: jest.fn(() => firstClose.promise),
+    } as unknown as RsvpSpeechController;
+    const secondController = {
+      prepare: jest.fn(async () => undefined),
+      close: jest.fn(async () => undefined),
+    } as unknown as RsvpSpeechController;
+
+    await expect(
+      prepareRsvpSpeechTrial(baseSetup(), {
+        createController: () => firstController,
+      }),
+    ).resolves.toBe(true);
+
+    const closePromise = closeActiveRsvpSpeechTrial();
+    expect(hasActiveRsvpSpeechResources()).toBe(true);
+
+    const createSecondController = jest.fn(() => secondController);
+    const nextPreparation = prepareRsvpSpeechTrial(
+      { ...baseSetup(), trialNumber: 8 },
+      { createController: createSecondController },
+    );
+    await Promise.resolve();
+    expect(createSecondController).not.toHaveBeenCalled();
+
+    firstClose.resolve();
+    await closePromise;
+    await expect(nextPreparation).resolves.toBe(true);
+    expect(createSecondController).toHaveBeenCalledTimes(1);
   });
 
   it("supports transcript injection without microphone or provider access", () => {

--- a/tests/rsvpSpeechScoring.test.ts
+++ b/tests/rsvpSpeechScoring.test.ts
@@ -1,0 +1,305 @@
+import {
+  RsvpSpeechScoringError,
+  scoreRsvpSpeechResponse,
+  type RsvpSpeechScoringPolicy,
+} from "../components/rsvpSpeech/rsvpSpeechScoring";
+
+const policy = (
+  overrides: Partial<RsvpSpeechScoringPolicy> = {},
+): RsvpSpeechScoringPolicy => ({
+  wordOrder: "strict",
+  repetition: "ignore",
+  selfCorrection: "accept",
+  ...overrides,
+});
+
+const score = (
+  transcript: string,
+  overrides: Partial<RsvpSpeechScoringPolicy> = {},
+) =>
+  scoreRsvpSpeechResponse({
+    targetWords: ["dog", "cat", "book"],
+    transcript,
+    languageCode: "en-US",
+    policy: policy(overrides),
+  });
+
+describe("RSVP speech scoring", () => {
+  it("returns the same ordered 0/1 payload shape expected by RSVP QUEST", () => {
+    const result = score("dog cat book");
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.targetResults.map((target) => target.correct)).toEqual([
+      1, 1, 1,
+    ]);
+  });
+
+  it("ignores unrelated filler while retaining diagnostics", () => {
+    const result = score("dog um cat book");
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.diagnostics.fillerCount).toBe(1);
+    expect(result.diagnostics.insertionCount).toBe(1);
+  });
+
+  it("scores words at the wrong positions as incorrect in strict mode", () => {
+    const result = score("cat dog book");
+
+    expect(result.responseVector).toEqual([0, 0, 1]);
+    expect(result.targetResults.map((target) => target.outcome)).toEqual([
+      "outOfOrder",
+      "outOfOrder",
+      "correct",
+    ]);
+    expect(result.diagnostics.outOfOrderCount).toBe(2);
+  });
+
+  it("can accept the same unique targets in any order when policy permits", () => {
+    const result = score("cat dog book", { wordOrder: "anyOrder" });
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+  });
+
+  it("preserves target positions around an omission", () => {
+    const result = score("dog book");
+
+    expect(result.responseVector).toEqual([1, 0, 1]);
+    expect(result.diagnostics.omissionCount).toBe(1);
+  });
+
+  it("supports both repetition policies without changing alignment", () => {
+    const ignored = score("dog dog cat book");
+    const rejected = score("dog dog cat book", {
+      repetition: "markIncorrect",
+    });
+
+    expect(ignored.responseVector).toEqual([1, 1, 1]);
+    expect(rejected.responseVector).toEqual([0, 1, 1]);
+    expect(ignored.diagnostics.repetitionCount).toBe(1);
+    expect(rejected.diagnostics.repetitionCount).toBe(1);
+  });
+
+  it("supports both self-correction policies", () => {
+    const accepted = score("dog cot cat book");
+    const rejected = score("dog cot cat book", {
+      selfCorrection: "markIncorrect",
+    });
+
+    expect(accepted.responseVector).toEqual([1, 1, 1]);
+    expect(rejected.responseVector).toEqual([1, 0, 1]);
+    expect(accepted.diagnostics.selfCorrectionCount).toBe(1);
+    expect(rejected.diagnostics.selfCorrectionCount).toBe(1);
+  });
+
+  it("does not guess that unrelated extra speech is a self-correction", () => {
+    const result = score("dog fish no cat book");
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.diagnostics.selfCorrectionCount).toBe(0);
+    expect(result.diagnostics.fillerCount).toBe(2);
+  });
+
+  it("records an early target word as out-of-order even if repeated later", () => {
+    const result = score("cat dog cat book");
+
+    expect(result.responseVector).toEqual([0, 1, 1]);
+    expect(result.diagnostics.outOfOrderCount).toBe(1);
+  });
+
+  it("rejects an empty transcript so it cannot be scored as incorrect", () => {
+    expect(() => score(" ")).toThrow(
+      expect.objectContaining<Partial<RsvpSpeechScoringError>>({
+        code: "emptyTranscript",
+      }),
+    );
+  });
+
+  it("scores Persian targets across a provider-created half-space boundary", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u0645\u06CC\u200C\u0631\u0648\u062F",
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+      ],
+      transcript:
+        "\u0645\u06CC \u0631\u0648\u062F \u0643\u062A\u0627\u0628 \u062E\u0627\u0646\u0647",
+      languageCode: "fa-IR",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.diagnostics.languageProfile).toBe("fa");
+    expect(
+      result.diagnostics.events.some(
+        (event) => event.matchKind === "joinedTranscript",
+      ),
+    ).toBe(true);
+  });
+
+  it("scores a missing Persian ZWNJ through an approved affix boundary", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u0645\u06CC\u0631\u0648\u062F",
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+      ],
+      transcript:
+        "\u0645\u06CC \u0631\u0648\u062F \u06A9\u062A\u0627\u0628 \u062E\u0627\u0646\u0647",
+      languageCode: "fa-IR",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.diagnostics.splitTranscriptCount).toBe(1);
+  });
+
+  it("scores one merged Persian STT token across adjacent targets", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+        "\u0639\u062F\u0633",
+      ],
+      transcript:
+        "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647 \u0639\u062F\u0633",
+      languageCode: "fa-IR",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+    expect(result.diagnostics.mergedTargetGroupCount).toBe(1);
+    expect(result.targetResults[0].responseText).toBe(
+      "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+    );
+    expect(result.targetResults[1].responseText).toBe(
+      "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+    );
+  });
+
+  it("applies repetition policy to every target represented by a merged token", () => {
+    const baseInput = {
+      targetWords: [
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+        "\u0639\u062F\u0633",
+      ],
+      transcript:
+        "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647 \u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647 \u0639\u062F\u0633",
+      languageCode: "fa",
+    } as const;
+    const ignored = scoreRsvpSpeechResponse({
+      ...baseInput,
+      policy: policy(),
+    });
+    const rejected = scoreRsvpSpeechResponse({
+      ...baseInput,
+      policy: policy({ repetition: "markIncorrect" }),
+    });
+
+    expect(ignored.responseVector).toEqual([1, 1, 1]);
+    expect(rejected.responseVector).toEqual([0, 0, 1]);
+    expect(rejected.diagnostics.repetitionCount).toBe(1);
+  });
+
+  it("never reuses one Persian token for an exact target and a merged group", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+        "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+      ],
+      transcript: "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+      languageCode: "fa",
+      policy: policy({ wordOrder: "anyOrder" }),
+    });
+
+    expect(result.responseVector).toEqual([0, 0, 1]);
+    expect(result.diagnostics.mergedTargetGroupCount).toBe(0);
+  });
+
+  it("does not turn a Persian phonetic candidate into a correct response", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u0635\u0628\u0631",
+        "\u06A9\u062A\u0627\u0628",
+        "\u062E\u0627\u0646\u0647",
+      ],
+      transcript:
+        "\u062B\u0628\u0631 \u06A9\u062A\u0627\u0628 \u062E\u0627\u0646\u0647",
+      languageCode: "fa",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([0, 1, 1]);
+    expect(result.diagnostics.phoneticCandidateCount).toBe(1);
+  });
+
+  it("does not turn two ordinary Persian words into one correct target", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+        "\u062F\u0631\u062E\u062A",
+        "\u062E\u0627\u0646\u0647",
+      ],
+      transcript:
+        "\u06A9\u062A\u0627\u0628 \u062E\u0627\u0646\u0647 \u062F\u0631\u062E\u062A \u062E\u0627\u0646\u0647",
+      languageCode: "fa-IR",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([0, 1, 1]);
+  });
+
+  it("scores repeated target positions allowed by the existing RSVP setting", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: ["dog", "dog", "book"],
+      transcript: "dog dog book",
+      languageCode: "en",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([1, 1, 1]);
+  });
+
+  it("keeps one repeated target position omitted when only one occurrence is spoken", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: ["dog", "dog", "book"],
+      transcript: "dog book",
+      languageCode: "en",
+      policy: policy(),
+    });
+
+    expect(result.responseVector.filter(Boolean)).toHaveLength(2);
+    expect(result.responseVector[2]).toBe(1);
+    expect(result.diagnostics.omissionCount).toBe(1);
+  });
+
+  it("handles targets that become equal after language normalization", () => {
+    const result = scoreRsvpSpeechResponse({
+      targetWords: [
+        "\u0645\u06CC\u200C\u0631\u0648\u062F",
+        "\u0645\u06CC\u0631\u0648\u062F",
+      ],
+      transcript:
+        "\u0645\u06CC\u0631\u0648\u062F \u0645\u06CC\u0631\u0648\u062F",
+      languageCode: "fa",
+      policy: policy(),
+    });
+
+    expect(result.responseVector).toEqual([1, 1]);
+  });
+
+  it("fails fast instead of silently applying an unknown scientific policy", () => {
+    expect(() =>
+      scoreRsvpSpeechResponse({
+        targetWords: ["dog", "cat", "book"],
+        transcript: "dog cat book",
+        languageCode: "en",
+        policy: {
+          ...policy(),
+          wordOrder: "unknown" as RsvpSpeechScoringPolicy["wordOrder"],
+        },
+      }),
+    ).toThrow("valid word-order policy");
+  });
+});

--- a/tests/rsvpSpeechValidity.test.ts
+++ b/tests/rsvpSpeechValidity.test.ts
@@ -1,0 +1,71 @@
+import { resolveRsvpSpeechTrialValidity } from "../components/rsvpSpeech/rsvpSpeechValidity";
+
+describe("RSVP automatic-speech trial validity", () => {
+  it.each(["silent", "spoken"] as const)(
+    "preserves the existing valid path for %s RSVP responses",
+    (responseMode) => {
+      expect(
+        resolveRsvpSpeechTrialValidity({
+          responseMode,
+          runtimeStatus: "idle",
+          captureStarted: false,
+          registeredResponseCount: 0,
+          expectedResponseCount: 3,
+        }),
+      ).toEqual({ validForQuest: true, consumeTargetWords: true });
+    },
+  );
+
+  it("does not give a failed pre-exposure trial to QUEST or consume its unseen words", () => {
+    expect(
+      resolveRsvpSpeechTrialValidity({
+        responseMode: "automaticSpeech",
+        runtimeStatus: "failed",
+        captureStarted: false,
+        registeredResponseCount: 0,
+        expectedResponseCount: 3,
+      }),
+    ).toEqual({
+      validForQuest: false,
+      consumeTargetWords: false,
+      invalidReason: "preExposureTechnicalFailure",
+    });
+  });
+
+  it("consumes exposed words but keeps a failed captured trial away from QUEST", () => {
+    expect(
+      resolveRsvpSpeechTrialValidity({
+        responseMode: "automaticSpeech",
+        runtimeStatus: "failed",
+        captureStarted: true,
+        registeredResponseCount: 0,
+        expectedResponseCount: 3,
+      }),
+    ).toEqual({
+      validForQuest: false,
+      consumeTargetWords: true,
+      invalidReason: "postExposureTechnicalFailure",
+    });
+  });
+
+  it("requires one registered response for every target after STT completes", () => {
+    expect(
+      resolveRsvpSpeechTrialValidity({
+        responseMode: "automaticSpeech",
+        runtimeStatus: "completed",
+        captureStarted: true,
+        registeredResponseCount: 0,
+        expectedResponseCount: 3,
+      }).validForQuest,
+    ).toBe(false);
+    expect(
+      resolveRsvpSpeechTrialValidity({
+        responseMode: "automaticSpeech",
+        runtimeStatus: "completed",
+        captureStarted: true,
+        registeredResponseCount: 3,
+        expectedResponseCount: 3,
+      }),
+    ).toEqual({ validForQuest: true, consumeTargetWords: true });
+  });
+});

--- a/tests/textNormalization.test.ts
+++ b/tests/textNormalization.test.ts
@@ -1,0 +1,101 @@
+import {
+  normalizeSpeechToken,
+  tokenizeSpeechTranscript,
+} from "../components/speech/textNormalization";
+
+describe("speech text normalization", () => {
+  it("normalizes English case and punctuation without removing lexical marks", () => {
+    const tokenization = tokenizeSpeechTranscript(
+      "DOG, cat! Don\u2019t co\u2011operate.",
+      "en-US",
+    );
+
+    expect(tokenization.profileId).toBe("en");
+    expect(tokenization.tokens.map((token) => token.normalized)).toEqual([
+      "dog",
+      "cat",
+      "don't",
+      "co-operate",
+    ]);
+  });
+
+  it("keeps Persian ZWNJ for audit while ignoring it during comparison", () => {
+    const withZwnj = normalizeSpeechToken(
+      "\u0645\u06CC\u200C\u0631\u0648\u062F",
+      "fa-IR",
+    );
+    const withoutZwnj = normalizeSpeechToken(
+      "\u0645\u06CC\u0631\u0648\u062F",
+      "fa",
+    );
+
+    expect(withZwnj.normalized).toBe("\u0645\u06CC\u200C\u0631\u0648\u062F");
+    expect(withZwnj.comparisonKey).toBe("\u0645\u06CC\u0631\u0648\u062F");
+    expect(withZwnj.comparisonKey).toBe(withoutZwnj.comparisonKey);
+  });
+
+  it("normalizes Persian Arabic-codepoint variants, tatweel, and diacritics", () => {
+    const token = normalizeSpeechToken(
+      "\u0643\u0650\u0640\u062A\u0627\u0628\u064A",
+      "fas",
+    );
+
+    expect(token.normalized).toBe("\u06A9\u062A\u0627\u0628\u06CC");
+    expect(token.profileId).toBe("fa");
+  });
+
+  it("keeps Persian spelling distinct while exposing phonetic evidence", () => {
+    const target = normalizeSpeechToken("\u0635\u0628\u0631", "fa");
+    const providerSpelling = normalizeSpeechToken("\u062B\u0628\u0631", "fa");
+
+    expect(target.comparisonKey).not.toBe(providerSpelling.comparisonKey);
+    expect(target.phoneticKeys).toEqual(providerSpelling.phoneticKeys);
+  });
+
+  it("does not invent phonetic evidence for English", () => {
+    expect(normalizeSpeechToken("sea", "en").phoneticKeys).toEqual([]);
+  });
+
+  it("keeps Persian words separated by ordinary whitespace as separate tokens", () => {
+    const tokenization = tokenizeSpeechTranscript(
+      "\u0645\u06CC \u0631\u0648\u062F",
+      "fa",
+    );
+
+    expect(tokenization.tokens.map((token) => token.normalized)).toEqual([
+      "\u0645\u06CC",
+      "\u0631\u0648\u062F",
+    ]);
+  });
+
+  it("treats visible whitespace around an existing ZWNJ as formatting noise", () => {
+    const tokenization = tokenizeSpeechTranscript(
+      "\u0645\u06CC \u200C \u0631\u0648\u062F",
+      "fa",
+    );
+
+    expect(tokenization.tokens).toHaveLength(1);
+    expect(tokenization.tokens[0].normalized).toBe(
+      "\u0645\u06CC\u200C\u0631\u0648\u062F",
+    );
+  });
+
+  it("uses a separate conservative Arabic profile", () => {
+    const token = normalizeSpeechToken("\u06CC\u06A9\u0629\u0622", "ar-SA");
+
+    expect(token.profileId).toBe("ar");
+    expect(token.normalized).toBe("\u064A\u0643\u0629\u0622");
+  });
+
+  it("splits Arabic-script punctuation boundaries", () => {
+    const tokenization = tokenizeSpeechTranscript(
+      "\u0633\u0644\u0627\u0645\u060C\u062F\u0646\u06CC\u0627",
+      "fa",
+    );
+
+    expect(tokenization.tokens.map((token) => token.normalized)).toEqual([
+      "\u0633\u0644\u0627\u0645",
+      "\u062F\u0646\u06CC\u0627",
+    ]);
+  });
+});

--- a/tests/tokenAlignment.test.ts
+++ b/tests/tokenAlignment.test.ts
@@ -1,0 +1,244 @@
+import {
+  alignSpeechTokensToTargets,
+  characterSimilarity,
+} from "../components/speech/tokenAlignment";
+import {
+  normalizeSpeechToken,
+  tokenizeSpeechTranscript,
+} from "../components/speech/textNormalization";
+
+const targets = (words: readonly string[], language = "en") =>
+  words.map((word) => normalizeSpeechToken(word, language));
+
+const transcript = (text: string, language = "en") =>
+  tokenizeSpeechTranscript(text, language).tokens;
+
+describe("position-aware speech token alignment", () => {
+  it("aligns an exact ordered response", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["dog", "cat", "book"]),
+      transcript("dog cat book"),
+    );
+
+    expect(result.events.map((event) => event.operation)).toEqual([
+      "match",
+      "match",
+      "match",
+    ]);
+    expect(result.totalCost).toBe(0);
+  });
+
+  it("keeps unrelated fillers as insertions without shifting later matches", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["dog", "cat", "book"]),
+      transcript("dog um cat book"),
+    );
+
+    expect(result.events.map((event) => event.operation)).toEqual([
+      "match",
+      "insertion",
+      "match",
+      "match",
+    ]);
+  });
+
+  it("treats target words spoken at another position as substitutions", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["dog", "cat", "book"]),
+      transcript("cat dog book"),
+    );
+
+    expect(
+      result.events.map((event) => [event.operation, event.matchKind]),
+    ).toEqual([
+      ["substitution", "outOfOrderTarget"],
+      ["substitution", "outOfOrderTarget"],
+      ["match", "exact"],
+    ]);
+  });
+
+  it("represents a missing target as an omission", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["dog", "cat", "book"]),
+      transcript("dog book"),
+    );
+
+    expect(result.events.map((event) => event.operation)).toEqual([
+      "match",
+      "omission",
+      "match",
+    ]);
+  });
+
+  it("keeps the leftmost exact occurrence and emits a trailing duplicate", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["dog", "cat", "book"]),
+      transcript("dog dog cat book"),
+    );
+
+    expect(
+      result.events.map((event) => [
+        event.operation,
+        event.targetIndex,
+        event.transcriptIndices[0],
+      ]),
+    ).toEqual([
+      ["match", 0, 0],
+      ["insertion", null, 1],
+      ["match", 1, 2],
+      ["match", 2, 3],
+    ]);
+  });
+
+  it("matches one Persian target against provider-split ZWNJ parts", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["\u0645\u06CC\u200C\u0631\u0648\u062F"], "fa"),
+      transcript("\u0645\u06CC \u0631\u0648\u062F", "fa"),
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      operation: "match",
+      matchKind: "joinedTranscript",
+      transcriptIndices: [0, 1],
+    });
+  });
+
+  it("repairs a common Persian prefix boundary when the source omitted ZWNJ", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["\u0645\u06CC\u0631\u0648\u062F"], "fa"),
+      transcript("\u0645\u06CC \u0631\u0648\u062F", "fa"),
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      operation: "match",
+      matchKind: "joinedTranscript",
+      boundaryMatchKind: "persianAffixBoundary",
+      transcriptIndices: [0, 1],
+    });
+  });
+
+  it("repairs a common Persian suffix boundary when the source omitted ZWNJ", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["\u06A9\u062A\u0627\u0628\u0647\u0627"], "fa"),
+      transcript("\u06A9\u062A\u0627\u0628 \u0647\u0627", "fa"),
+    );
+
+    expect(result.events[0]).toMatchObject({
+      operation: "match",
+      boundaryMatchKind: "persianAffixBoundary",
+    });
+  });
+
+  it("does not merge ordinary Persian words when the target has no ZWNJ", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647"], "fa"),
+      transcript("\u06A9\u062A\u0627\u0628 \u062E\u0627\u0646\u0647", "fa"),
+    );
+
+    expect(result.events.some((event) => event.operation === "match")).toBe(
+      false,
+    );
+  });
+
+  it("maps one merged Persian STT token to adjacent target positions", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(
+        [
+          "\u06A9\u062A\u0627\u0628",
+          "\u062E\u0627\u0646\u0647",
+          "\u0639\u062F\u0633",
+        ],
+        "fa",
+      ),
+      transcript(
+        "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647 \u0639\u062F\u0633",
+        "fa",
+      ),
+    );
+
+    expect(result.events).toHaveLength(2);
+    expect(result.events[0]).toMatchObject({
+      operation: "match",
+      matchKind: "mergedTargets",
+      targetIndex: 0,
+      targetIndices: [0, 1],
+      transcriptIndices: [0],
+    });
+    expect(result.events[1]).toMatchObject({
+      operation: "match",
+      matchKind: "exact",
+      targetIndices: [2],
+    });
+  });
+
+  it("prefers an exact Persian target over a competing concatenated span", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(
+        [
+          "\u06A9\u062A\u0627\u0628",
+          "\u062E\u0627\u0646\u0647",
+          "\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647",
+        ],
+        "fa",
+      ),
+      transcript("\u06A9\u062A\u0627\u0628\u062E\u0627\u0646\u0647", "fa"),
+    );
+
+    expect(
+      result.events.some((event) => event.matchKind === "mergedTargets"),
+    ).toBe(false);
+    expect(result.events.at(-1)).toMatchObject({
+      operation: "match",
+      matchKind: "exact",
+      targetIndices: [2],
+    });
+  });
+
+  it("does not concatenate adjacent English targets", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["cat", "dog"], "en"),
+      transcript("catdog", "en"),
+    );
+
+    expect(
+      result.events.some((event) => event.matchKind === "mergedTargets"),
+    ).toBe(false);
+    expect(result.events.some((event) => event.operation === "match")).toBe(
+      false,
+    );
+  });
+
+  it("uses Persian phonetic equivalence as a substitution diagnostic only", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["\u0635\u0628\u0631"], "fa"),
+      transcript("\u062B\u0628\u0631", "fa"),
+    );
+
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0]).toMatchObject({
+      operation: "substitution",
+      matchKind: "phoneticCandidate",
+    });
+  });
+
+  it("does not force an unrelated word onto a target", () => {
+    const result = alignSpeechTokensToTargets(
+      targets(["cat"]),
+      transcript("fish"),
+    );
+
+    expect(result.events.map((event) => event.operation).sort()).toEqual([
+      "insertion",
+      "omission",
+    ]);
+  });
+
+  it("computes Unicode-aware character similarity", () => {
+    expect(characterSimilarity("cat", "cot")).toBeCloseTo(2 / 3);
+    expect(
+      characterSimilarity("\u06A9\u062A\u0627\u0628", "\u06A9\u062A\u0628"),
+    ).toBe(0.75);
+  });
+});

--- a/threshold.js
+++ b/threshold.js
@@ -4604,16 +4604,6 @@ const experiment = (howManyBlocksAreThereInTotal) => {
         },
         rsvpReading: () => {
           renderObj.tinyHint.setAutoDraw(false);
-          const rsvpReadingBlockInstructs =
-            initialInstructions +
-            instructionsText.initialByThresholdParameter["timing"](
-              L,
-              responseType.current,
-              paramReader
-                .read("conditionTrials", status.block)
-                .reduce((a, b) => a + b),
-            );
-          _instructionSetup(rsvpReadingBlockInstructs, status.block, true, 1.0);
           rsvpReadingResponse.responseTypeForCurrentBlock =
             resolveRsvpReadingBlockResponseModes({
               responseSpokenBool: paramReader.read(
@@ -4625,6 +4615,35 @@ const experiment = (howManyBlocksAreThereInTotal) => {
                 status.block,
               ),
             });
+          const totalTrials = paramReader
+            .read("conditionTrials", status.block)
+            .reduce((a, b) => a + b);
+          const automaticSpeechModes =
+            rsvpReadingResponse.responseTypeForCurrentBlock.filter((mode) =>
+              isRsvpReadingAutomaticSpeechResponseMode(mode),
+            );
+          const automaticSpeechOnly =
+            automaticSpeechModes.length > 0 &&
+            automaticSpeechModes.length ===
+              rsvpReadingResponse.responseTypeForCurrentBlock.length;
+          let rsvpReadingBlockInstructs =
+            initialInstructions +
+            (automaticSpeechOnly
+              ? instructionsText.rsvpReadingAutomaticSpeechBegin(
+                  L,
+                  responseType.current,
+                  totalTrials,
+                )
+              : instructionsText.initialByThresholdParameter["timing"](
+                  L,
+                  responseType.current,
+                  totalTrials,
+                ));
+          if (automaticSpeechModes.length > 0 && !automaticSpeechOnly) {
+            rsvpReadingBlockInstructs +=
+              instructionsText.rsvpReadingAutomaticSpeechResponse(L);
+          }
+          _instructionSetup(rsvpReadingBlockInstructs, status.block, true, 1.0);
           rsvpReadingWordsForThisBlock.current = getThisBlockRSVPReadingWords(
             paramReader,
             status.block,
@@ -6222,7 +6241,7 @@ const experiment = (howManyBlocksAreThereInTotal) => {
                   status.block_condition,
                 ),
                 targetWords: thisTrialWords.targetWords,
-                experimentLanguage: rc.language.value,
+                conditionLanguage: paramReader.read("fontLanguage", BC) || "en",
                 targetKeytermBiasEnabled: paramReader.read(
                   RSVP_SPEECH_PARAMETER_NAMES.targetKeytermBiasEnabled,
                   status.block_condition,
@@ -6610,7 +6629,17 @@ const experiment = (howManyBlocksAreThereInTotal) => {
         letterConfig?.thresholdParameter === "spacingDeg"
       )
         doubleCheckSizeToSpacing(target, flanker1, stimulusParameters);
-      if (rsvpSpeechPreparationPromise) await rsvpSpeechPreparationPromise;
+      if (rsvpSpeechPreparationPromise) {
+        const prepared = await rsvpSpeechPreparationPromise;
+        psychoJS.experiment.addData(
+          "rsvpSpeechPreparationSucceededBool",
+          prepared,
+        );
+        if (!prepared) {
+          removeSkipTrialButton();
+          skipTrial();
+        }
+      }
       /* --------------------------------- \PUBLIC -------------------------------- */
       return Scheduler.Event.NEXT;
     };


### PR DESCRIPTION
## Summary

- Add RSVP speech transcript scoring and target position alignment.
- Normalize multilingual speech responses before scoring.
- Mark technical speech failures as invalid instead of incorrect.
- Preserve existing matrix and experimenter-scoring modes.

## Testing

- TypeScript check passed.
- RSVP speech scoring, normalization, alignment, runtime, and validity tests passed.